### PR TITLE
Added config for ML Engine Batch Prediction Operator.

### DIFF
--- a/boundary_layer_default_plugin/config/operators/ml_engine_batch_prediction.yaml
+++ b/boundary_layer_default_plugin/config/operators/ml_engine_batch_prediction.yaml
@@ -1,0 +1,60 @@
+# Copyright 2018 Etsy Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+name: ml_engine_batch_prediction
+operator_class: MLEngineBatchPredictionOperator
+operator_class_module: airflow.contrib.operators.mlengine_operator
+schema_extends: base
+parameters_jsonschema:
+    properties:
+        project_id:
+            type: string
+        job_id:
+            type: string
+        data_format:
+            type: string
+            enum:
+                - DATA_FORMAT_UNSPECIFIED
+                - JSON
+                - TEXT
+                - TF_RECORD
+                - TF_RECORD_GZIP
+        input_paths:
+            type: array
+        items:
+            type: string
+        output_path:
+            type: string
+        region:
+            type: string
+        model_name:
+            type: string
+        version_name:
+            type: string
+        uri:
+            type: string
+        max_worker_count:
+            type: integer
+        runtime_version:
+            type: string
+        gcp_conn_id:
+            type: string
+        delegate_to:
+            type: string
+    required:
+        - project_id
+        - job_id
+        - input_paths
+        - output_path
+        - region
+    additionalProperties: false


### PR DESCRIPTION
The changes here add the yaml config necessary for using the ML Engine Batch Prediction operator, as described [in the Airflow documentation](https://airflow.apache.org/integration.html#mlenginebatchpredictionoperator).

