### PR TITLE
Validate default plugin

### DIFF
--- a/boundary_layer/exceptions.py
+++ b/boundary_layer/exceptions.py
@@ -56,3 +56,7 @@ class InvalidFlowControlNode(Exception):
 
 class MissingPreprocessorException(Exception):
     pass
+
+
+class DuplicateRegistryConfigName(Exception):
+    pass

--- a/boundary_layer/exceptions.py
+++ b/boundary_layer/exceptions.py
@@ -60,3 +60,7 @@ class MissingPreprocessorException(Exception):
 
 class DuplicateRegistryConfigName(Exception):
     pass
+
+
+class InvalidConfig(Exception):
+    pass

--- a/boundary_layer/registry/registry.py
+++ b/boundary_layer/registry/registry.py
@@ -20,7 +20,7 @@ import yaml
 
 from boundary_layer.logger import logger
 from boundary_layer import util
-from boundary_layer.exceptions import DuplicateRegistryConfigName
+from boundary_layer.exceptions import DuplicateRegistryConfigName, InvalidConfig
 
 
 class NodeTypes(Enum):
@@ -180,7 +180,7 @@ class ConfigFileRegistry(Registry):
 
         loaded = self.spec_schema_cls().load(item)
         if loaded.errors:
-            raise Exception('Invalid config spec in file {}: {}'.format(
+            raise InvalidConfig('Invalid config spec in file {}: {}'.format(
                 filename, loaded.errors))
 
         return loaded.data

--- a/boundary_layer/registry/registry.py
+++ b/boundary_layer/registry/registry.py
@@ -216,7 +216,8 @@ class ConfigFileRegistry(Registry):
 
         if duplicates:
             raise DuplicateRegistryConfigName(
-                'Duplicate names found while loading registry: `{}` (full configurations: {})'.format(
+                'Duplicate names found while loading registry: `{}` '
+                '(full configurations: {})'.format(
                     '`, `'.join(duplicates.keys()),
                     duplicates))
 

--- a/test/data/registry/invalid-bad-config/operators/base.yaml
+++ b/test/data/registry/invalid-bad-config/operators/base.yaml
@@ -1,0 +1,74 @@
+# Copyright 2018 Etsy Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+# This operator matches the airflow base operator.  For information on
+# its parameters, see:
+# https://github.com/apache/incubator-airflow/blob/1.9.0/airflow/models.py#L1986
+name: base
+operator_class: BaseOperator
+operator_class_module: airflow.model
+parameters_jsonschema:
+    fields: #  intentionally invalid
+        owner:
+            type: string
+        email:
+            type: array
+            items:
+                type: string
+                format: email
+        retries:
+            type: integer
+        retry_delay:
+            type: integer
+        retry_exponential_backoff:
+            type: boolean
+        max_retry_delay:
+            type: string
+        start_date:
+            type: string
+        end_date:
+            type: string
+        depends_on_past:
+            type: boolean
+        wait_for_downstream:
+            type: boolean
+        queue:
+            type: string
+        priority_weight:
+            type: string
+        pool:
+            type: string
+        sla:
+            type: integer
+        execution_timeout:
+            type: integer
+        on_failure_callback:
+            type: string
+        on_retry_callback:
+            type: string
+        on_success_callback:
+            type: string
+        trigger_rule:
+            type: string
+            enum: [ all_success, all_failed, all_done, one_success, one_failed, dummy ]
+        task_concurrency:
+            type: integer
+        dag:
+            type: string
+        task_id:
+            type: string
+    additionalProperties: false
+    required:
+        - dag
+        - task_id

--- a/test/data/registry/invalid-duplicate-names/operators/base.yaml
+++ b/test/data/registry/invalid-duplicate-names/operators/base.yaml
@@ -1,0 +1,74 @@
+# Copyright 2018 Etsy Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+# This operator matches the airflow base operator.  For information on
+# its parameters, see:
+# https://github.com/apache/incubator-airflow/blob/1.9.0/airflow/models.py#L1986
+name: base
+operator_class: BaseOperator
+operator_class_module: airflow.model
+parameters_jsonschema:
+    properties:
+        owner:
+            type: string
+        email:
+            type: array
+            items:
+                type: string
+                format: email
+        retries:
+            type: integer
+        retry_delay:
+            type: integer
+        retry_exponential_backoff:
+            type: boolean
+        max_retry_delay:
+            type: string
+        start_date:
+            type: string
+        end_date:
+            type: string
+        depends_on_past:
+            type: boolean
+        wait_for_downstream:
+            type: boolean
+        queue:
+            type: string
+        priority_weight:
+            type: string
+        pool:
+            type: string
+        sla:
+            type: integer
+        execution_timeout:
+            type: integer
+        on_failure_callback:
+            type: string
+        on_retry_callback:
+            type: string
+        on_success_callback:
+            type: string
+        trigger_rule:
+            type: string
+            enum: [ all_success, all_failed, all_done, one_success, one_failed, dummy ]
+        task_concurrency:
+            type: integer
+        dag:
+            type: string
+        task_id:
+            type: string
+    additionalProperties: false
+    required:
+        - dag
+        - task_id

--- a/test/data/registry/invalid-duplicate-names/operators/base2.yaml
+++ b/test/data/registry/invalid-duplicate-names/operators/base2.yaml
@@ -1,0 +1,19 @@
+# Copyright 2018 Etsy Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+name: base
+operator_class: DummyOperator
+operator_class_module: airflow.operators.dummy_operator
+parameters_jsonschema:
+    additionalProperties: true

--- a/test/default_plugin/test_plugin.py
+++ b/test/default_plugin/test_plugin.py
@@ -1,0 +1,11 @@
+# We must import the plugin manager in order to preload the plugin
+from boundary_layer.plugins import manager
+from boundary_layer_default_plugin.plugin import DefaultPlugin
+
+
+def test_valid_plugin():
+    """ Make sure we can instantiate the default plugin.  This will
+        flag any errors that may exist in the plugin's registries.
+    """
+    plugin = DefaultPlugin()
+    assert plugin is not None

--- a/test/registry/types/test_operator_registry.py
+++ b/test/registry/types/test_operator_registry.py
@@ -1,7 +1,10 @@
 import pytest
 import jsonschema
 from boundary_layer.containers import ExecutionContext
-from boundary_layer.exceptions import MissingPreprocessorException, DuplicateRegistryConfigName, InvalidConfig
+from boundary_layer.exceptions import \
+        MissingPreprocessorException, \
+        DuplicateRegistryConfigName, \
+        InvalidConfig
 from boundary_layer.registry.types import OperatorRegistry
 
 

--- a/test/registry/types/test_operator_registry.py
+++ b/test/registry/types/test_operator_registry.py
@@ -1,7 +1,7 @@
 import pytest
 import jsonschema
 from boundary_layer.containers import ExecutionContext
-from boundary_layer.exceptions import MissingPreprocessorException, DuplicateRegistryConfigName
+from boundary_layer.exceptions import MissingPreprocessorException, DuplicateRegistryConfigName, InvalidConfig
 from boundary_layer.registry.types import OperatorRegistry
 
 
@@ -87,4 +87,11 @@ def test_detect_duplicate_names():
     path = "test/data/registry/invalid-duplicate-names/operators"
 
     with pytest.raises(DuplicateRegistryConfigName):
+        OperatorRegistry([path])
+
+
+def test_detect_invalid_jsonschema():
+    path = "test/data/registry/invalid-bad-config/operators"
+
+    with pytest.raises(InvalidConfig):
         OperatorRegistry([path])

--- a/test/registry/types/test_operator_registry.py
+++ b/test/registry/types/test_operator_registry.py
@@ -1,7 +1,8 @@
 import pytest
 import jsonschema
 from boundary_layer.containers import ExecutionContext
-from boundary_layer.exceptions import MissingPreprocessorException
+from boundary_layer.exceptions import MissingPreprocessorException, DuplicateRegistryConfigName
+from boundary_layer.registry.types import OperatorRegistry
 
 
 def test_operator_registry(valid_operator_registry):
@@ -80,3 +81,10 @@ def test_fail_on_missing_preprocessor(valid_operator_registry):
             default_task_args={},
             base_operator_loader=valid_operator_registry.get,
             preprocessor_loader=None)
+
+
+def test_detect_duplicate_names():
+    path = "test/data/registry/invalid-duplicate-names/operators"
+
+    with pytest.raises(DuplicateRegistryConfigName):
+        OperatorRegistry([path])


### PR DESCRIPTION
This adds an explicit check to make sure that the default plugin can be instantiated, and further adds tests to make sure that the registry validator logic works properly.  This includes a minor fix, because it did not work properly previously...