### PR TITLE
Fixed the type of the max_worker_count param for MLEngine Batch Pred

### DIFF
--- a/boundary_layer_default_plugin/config/operators/ml_engine_batch_prediction.yaml
+++ b/boundary_layer_default_plugin/config/operators/ml_engine_batch_prediction.yaml
@@ -33,8 +33,8 @@ parameters_jsonschema:
                 - TF_RECORD_GZIP
         input_paths:
             type: array
-        items:
-            type: string
+            items:
+                type: string
         output_path:
             type: string
         region:
@@ -46,7 +46,7 @@ parameters_jsonschema:
         uri:
             type: string
         max_worker_count:
-            type: integer
+            type: string
         runtime_version:
             type: string
         gcp_conn_id:


### PR DESCRIPTION
The type for the `max_worker_count` parameter for the ML Engine Batch Prediction
operator was set to `integer`, matching the airflow doc on the operator, but the
Google API expects a string value (a string formatted int64 to be precise).

The changes here fix the type mismatch issue and add typing to the input_paths
parameter's items, which was previously missing.