### PR TITLE
Add batch support to generator framework

### DIFF
--- a/boundary_layer/builders/templates/generator_operator.j2
+++ b/boundary_layer/builders/templates/generator_operator.j2
@@ -45,8 +45,8 @@ def {{ item_name_builder }}(index, item):
 def {{ batch_name_builder }}(index, items):
     return 'batch_%d_%d' % (index, len(items))
 
-{# TODO: Import this from some util module #}
-def filter_with_blocklist(items, item_name_builder, blocklist):
+{# TODO: Import this from some util module when such functionality is possible #}
+def generator_helper_filter_with_blocklist(items, item_name_builder, blocklist):
     def not_in_blocklist(index, item):
         item_name = item_name_builder(index, item)
         return not any(re.match(i, item_name) for i in blocklist)
@@ -55,16 +55,16 @@ def filter_with_blocklist(items, item_name_builder, blocklist):
 
     return map(lambda t: t[1], filtered)
 
-{# TODO: Import this from some util module #}
-{# https://stackoverflow.com/a/312464 #}
-def grouped(l, n):
+{# TODO: Import this from some util module when such functionality is possible #}
+{# Borrowed from: https://stackoverflow.com/a/312464 #}
+def generator_helper_grouped_list(l, n):
     for i in range(0, len(l), n):
         yield l[i:i + n]
 
 {% set filtered = (node.name + '_filtered') | sanitize_operator_name %}
-{{ filtered }} = filter_with_blocklist({{ all_items }}, {{ item_name_builder }}, {{ blocklist }})
+{{ filtered }} = generator_helper_filter_with_blocklist({{ all_items }}, {{ item_name_builder }}, {{ blocklist }})
 
-for (index, items) in enumerate(grouped({{ filtered }}, {{ node.batching.batch_size }})):
+for (index, items) in enumerate(generator_helper_grouped_list({{ filtered }}, {{ node.batching.batch_size }})):
     batch_name = {{ batch_name_builder }}(index, items)
 
 {% set item_input = 'items' %}

--- a/boundary_layer/builders/templates/generator_operator.j2
+++ b/boundary_layer/builders/templates/generator_operator.j2
@@ -21,14 +21,51 @@ def {{ iterable_builder }}({{ ', '.join(builder_args) }}):
 {% set blocklist = (node.name + '_blocklist') | sanitize_operator_name %}
 {{ blocklist }} = {{ node.regex_blocklist }}
 
-{% set item_name_builder = (node.name + '_item_name_builder') | sanitize_operator_name %}
-def {{ item_name_builder }}(index, item):
-{{ node.config.item_name_builder_code | add_leading_spaces(1) }}
-
 {# Note: we use resolved_properties rather than operator_args, because the
  latter would discard any default task args, expecting them to be filled-in
  by airflow, while in fact airflow would not fill them in at all. #}
 {% set properties = node.resolved_properties.values %}
+
+{% if node.batching.enabled %}
+{# Generate code for batched situations #}
+{% set batch_name_builder = (node.name + '_batch_name_builder') | sanitize_operator_name %}
+def {{ batch_name_builder }}(index, items):
+    return 'batch_%d_%d' % (index, len(items))
+
+
+{# TODO: Import this from some util module #}
+{# https://stackoverflow.com/a/312464 #}
+def grouped(l, n):
+    for i in range(0, len(l), n):
+        yield l[i:i + n]
+
+items = {{ iterable_builder }}(
+{% for arg in builder_args %}
+{% if arg in properties %}
+            {{ arg }} = {{ properties[arg] | format_value }},
+{% endif %}
+{% endfor %}
+        )
+for (index, batch) in enumerate(grouped(items, {{ node.batching.batch_size }})):
+    batch_name = {{ batch_name_builder }}(index, items)
+    {# TODO: How do we handle this? #}
+    blocklist_match = any(re.match(i, item_name) for i in {{ blocklist }})
+    if blocklist_match:
+        continue
+
+    {{ node.target | sanitize_operator_name }}_builder(
+        index = index,
+        items = items,
+        batch_name = batch_name,
+        dag = dag,
+        upstream_dependencies = {{ upstream_dependencies | sanitize_operator_name | verbatim | format_value }},
+        downstream_dependencies = {{ downstream_dependencies | sanitize_operator_name | verbatim | format_value }})
+{% else %}
+{# Generate code for non-batched situations #}
+{% set item_name_builder = (node.name + '_item_name_builder') | sanitize_operator_name %}
+def {{ item_name_builder }}(index, item):
+{{ node.config.item_name_builder_code | add_leading_spaces(1) }}
+
 for (index, item) in enumerate({{ iterable_builder }}(
 {% for arg in builder_args %}
 {% if arg in properties %}
@@ -49,4 +86,5 @@ for (index, item) in enumerate({{ iterable_builder }}(
         dag = dag,
         upstream_dependencies = {{ upstream_dependencies | sanitize_operator_name | verbatim | format_value }},
         downstream_dependencies = {{ downstream_dependencies | sanitize_operator_name | verbatim | format_value }})
+{% endif %}
 

--- a/boundary_layer/builders/templates/generator_operator.j2
+++ b/boundary_layer/builders/templates/generator_operator.j2
@@ -39,7 +39,7 @@ def {{ item_name_builder }}(index, item):
 {% endfor %}
         )
 
-{% if node.batching|length > 0 and not node.batching.disabled %}
+{% if node.batching_enabled %}
 {# Generate code for batched situations #}
 {% set batch_name_builder = (node.name + '_batch_name_builder') | sanitize_operator_name %}
 def {{ batch_name_builder }}(index, items):

--- a/boundary_layer/builders/templates/generator_operator.j2
+++ b/boundary_layer/builders/templates/generator_operator.j2
@@ -18,12 +18,12 @@ You may obtain a copy of the License at
 def {{ iterable_builder }}({{ ', '.join(builder_args) }}):
 {{ node.config.iterator_builder_method_code | add_leading_spaces(1) }}
 
+{% set blocklist = (node.name + '_blocklist') | sanitize_operator_name %}
+{{ blocklist }} = {{ node.regex_blocklist }}
+
 {% set item_name_builder = (node.name + '_item_name_builder') | sanitize_operator_name %}
 def {{ item_name_builder }}(index, item):
 {{ node.config.item_name_builder_code | add_leading_spaces(1) }}
-
-{% set blocklist = (node.name + '_blocklist') | sanitize_operator_name %}
-{{ blocklist }} = {{ node.regex_blocklist }}
 
 {# Note: we use resolved_properties rather than operator_args, because the
  latter would discard any default task args, expecting them to be filled-in

--- a/boundary_layer/builders/templates/generator_operator.j2
+++ b/boundary_layer/builders/templates/generator_operator.j2
@@ -48,13 +48,13 @@ def grouped(l, n):
 
 for (index, batch) in enumerate(grouped(items, {{ node.batching.batch_size }})):
     batch_name = {{ batch_name_builder }}(index, items)
-    {# TODO: How do we handle this? #}
+{# TODO: How do we handle this? #}
     blocklist_match = any(re.match(i, item_name) for i in {{ blocklist }})
     if blocklist_match:
         continue
 
-    {% set item_input = 'items' %}
-    {% set name_input = 'batch_name' %}
+{% set item_input = 'items' %}
+{% set name_input = 'batch_name' %}
 {% else %}
 {# Generate code for non-batched situations #}
 {% set item_name_builder = (node.name + '_item_name_builder') | sanitize_operator_name %}
@@ -67,8 +67,8 @@ for (index, item) in enumerate(items):
     if blocklist_match:
         continue
 
-    {% set item_input = 'item' %}
-    {% set name_input = 'item_name' %}
+{% set item_input = 'item' %}
+{% set name_input = 'item_name' %}
 {% endif %}
     {{ node.target | sanitize_operator_name }}_builder(
         index = index,

--- a/boundary_layer/builders/templates/generator_operator.j2
+++ b/boundary_layer/builders/templates/generator_operator.j2
@@ -39,7 +39,7 @@ def {{ item_name_builder }}(index, item):
 {% endfor %}
         )
 
-{% if node.batching.enabled %}
+{% if node.batching|length > 0 and not node.batching.disabled %}
 {# Generate code for batched situations #}
 {% set batch_name_builder = (node.name + '_batch_name_builder') | sanitize_operator_name %}
 def {{ batch_name_builder }}(index, items):

--- a/boundary_layer/builders/templates/generator_operator.j2
+++ b/boundary_layer/builders/templates/generator_operator.j2
@@ -53,13 +53,8 @@ for (index, batch) in enumerate(grouped(items, {{ node.batching.batch_size }})):
     if blocklist_match:
         continue
 
-    {{ node.target | sanitize_operator_name }}_builder(
-        index = index,
-        items = items,
-        batch_name = batch_name,
-        dag = dag,
-        upstream_dependencies = {{ upstream_dependencies | sanitize_operator_name | verbatim | format_value }},
-        downstream_dependencies = {{ downstream_dependencies | sanitize_operator_name | verbatim | format_value }})
+    {% set item_input = 'items' %}
+    {% set name_input = 'batch_name' %}
 {% else %}
 {# Generate code for non-batched situations #}
 {% set item_name_builder = (node.name + '_item_name_builder') | sanitize_operator_name %}
@@ -72,12 +67,14 @@ for (index, item) in enumerate(items):
     if blocklist_match:
         continue
 
+    {% set item_input = 'item' %}
+    {% set name_input = 'item_name' %}
+{% endif %}
     {{ node.target | sanitize_operator_name }}_builder(
         index = index,
-        item = item,
-        item_name = item_name,
+        {{ item_input }} = {{ item_input }},
+        {{ name_input }} = {{ name_input }},
         dag = dag,
         upstream_dependencies = {{ upstream_dependencies | sanitize_operator_name | verbatim | format_value }},
         downstream_dependencies = {{ downstream_dependencies | sanitize_operator_name | verbatim | format_value }})
-{% endif %}
 

--- a/boundary_layer/builders/templates/generator_operator.j2
+++ b/boundary_layer/builders/templates/generator_operator.j2
@@ -26,19 +26,6 @@ def {{ iterable_builder }}({{ ', '.join(builder_args) }}):
  by airflow, while in fact airflow would not fill them in at all. #}
 {% set properties = node.resolved_properties.values %}
 
-{% if node.batching.enabled %}
-{# Generate code for batched situations #}
-{% set batch_name_builder = (node.name + '_batch_name_builder') | sanitize_operator_name %}
-def {{ batch_name_builder }}(index, items):
-    return 'batch_%d_%d' % (index, len(items))
-
-
-{# TODO: Import this from some util module #}
-{# https://stackoverflow.com/a/312464 #}
-def grouped(l, n):
-    for i in range(0, len(l), n):
-        yield l[i:i + n]
-
 items = {{ iterable_builder }}(
 {% for arg in builder_args %}
 {% if arg in properties %}
@@ -46,6 +33,19 @@ items = {{ iterable_builder }}(
 {% endif %}
 {% endfor %}
         )
+
+{% if node.batching.enabled %}
+{# Generate code for batched situations #}
+{% set batch_name_builder = (node.name + '_batch_name_builder') | sanitize_operator_name %}
+def {{ batch_name_builder }}(index, items):
+    return 'batch_%d_%d' % (index, len(items))
+
+{# TODO: Import this from some util module #}
+{# https://stackoverflow.com/a/312464 #}
+def grouped(l, n):
+    for i in range(0, len(l), n):
+        yield l[i:i + n]
+
 for (index, batch) in enumerate(grouped(items, {{ node.batching.batch_size }})):
     batch_name = {{ batch_name_builder }}(index, items)
     {# TODO: How do we handle this? #}
@@ -66,14 +66,7 @@ for (index, batch) in enumerate(grouped(items, {{ node.batching.batch_size }})):
 def {{ item_name_builder }}(index, item):
 {{ node.config.item_name_builder_code | add_leading_spaces(1) }}
 
-for (index, item) in enumerate({{ iterable_builder }}(
-{% for arg in builder_args %}
-{% if arg in properties %}
-            {{ arg }} = {{ properties[arg] | format_value }},
-{% endif %}
-{% endfor %}
-        )):
-
+for (index, item) in enumerate(items):
     item_name = {{ item_name_builder }}(index, item)
     blocklist_match = any(re.match(i, item_name) for i in {{ blocklist }})
     if blocklist_match:

--- a/boundary_layer/builders/templates/generator_operator.j2
+++ b/boundary_layer/builders/templates/generator_operator.j2
@@ -18,6 +18,10 @@ You may obtain a copy of the License at
 def {{ iterable_builder }}({{ ', '.join(builder_args) }}):
 {{ node.config.iterator_builder_method_code | add_leading_spaces(1) }}
 
+{% set item_name_builder = (node.name + '_item_name_builder') | sanitize_operator_name %}
+def {{ item_name_builder }}(index, item):
+{{ node.config.item_name_builder_code | add_leading_spaces(1) }}
+
 {% set blocklist = (node.name + '_blocklist') | sanitize_operator_name %}
 {{ blocklist }} = {{ node.regex_blocklist }}
 
@@ -26,7 +30,8 @@ def {{ iterable_builder }}({{ ', '.join(builder_args) }}):
  by airflow, while in fact airflow would not fill them in at all. #}
 {% set properties = node.resolved_properties.values %}
 
-items = {{ iterable_builder }}(
+{% set all_items = (node.name + '_all_items') | sanitize_operator_name %}
+{{ all_items }} = {{ iterable_builder }}(
 {% for arg in builder_args %}
 {% if arg in properties %}
             {{ arg }} = {{ properties[arg] | format_value }},
@@ -41,27 +46,32 @@ def {{ batch_name_builder }}(index, items):
     return 'batch_%d_%d' % (index, len(items))
 
 {# TODO: Import this from some util module #}
+def filter_with_blocklist(items, item_name_builder, blocklist):
+    def not_in_blocklist(index, item):
+        item_name = item_name_builder(index, item)
+        return not any(re.match(i, item_name) for i in blocklist)
+
+    filtered = filter(lambda (index, item): not_in_blocklist(index, item), enumerate(items))
+
+    return map(lambda t: t[1], filtered)
+
+{# TODO: Import this from some util module #}
 {# https://stackoverflow.com/a/312464 #}
 def grouped(l, n):
     for i in range(0, len(l), n):
         yield l[i:i + n]
 
-for (index, batch) in enumerate(grouped(items, {{ node.batching.batch_size }})):
+{% set filtered = (node.name + '_filtered') | sanitize_operator_name %}
+{{ filtered }} = filter_with_blocklist({{ all_items }}, {{ item_name_builder }}, {{ blocklist }})
+
+for (index, items) in enumerate(grouped({{ filtered }}, {{ node.batching.batch_size }})):
     batch_name = {{ batch_name_builder }}(index, items)
-{# TODO: How do we handle this? #}
-    blocklist_match = any(re.match(i, item_name) for i in {{ blocklist }})
-    if blocklist_match:
-        continue
 
 {% set item_input = 'items' %}
 {% set name_input = 'batch_name' %}
 {% else %}
 {# Generate code for non-batched situations #}
-{% set item_name_builder = (node.name + '_item_name_builder') | sanitize_operator_name %}
-def {{ item_name_builder }}(index, item):
-{{ node.config.item_name_builder_code | add_leading_spaces(1) }}
-
-for (index, item) in enumerate(items):
+for (index, item) in enumerate({{ all_items }}):
     item_name = {{ item_name_builder }}(index, item)
     blocklist_match = any(re.match(i, item_name) for i in {{ blocklist }})
     if blocklist_match:

--- a/boundary_layer/builders/templates/generator_preamble.j2
+++ b/boundary_layer/builders/templates/generator_preamble.j2
@@ -13,7 +13,7 @@ You may obtain a copy of the License at
     See the License for the specific language governing permissions and
     limitations under the License.
 #}
-{% if referring_node.batching|length > 0 and not referring_node.batching.disabled %}
+{% if referring_node.batching_enabled %}
     {%- set item_input = 'items' %}
     {%- set name_input = 'batch_name' %}
 {% else %}

--- a/boundary_layer/builders/templates/generator_preamble.j2
+++ b/boundary_layer/builders/templates/generator_preamble.j2
@@ -13,7 +13,7 @@ You may obtain a copy of the License at
     See the License for the specific language governing permissions and
     limitations under the License.
 #}
-{% if referring_node.batching.enabled %}
+{% if referring_node.batching|length > 0 and not referring_node.batching.disabled %}
     {%- set item_input = 'items' %}
     {%- set name_input = 'batch_name' %}
 {% else %}

--- a/boundary_layer/builders/templates/generator_preamble.j2
+++ b/boundary_layer/builders/templates/generator_preamble.j2
@@ -13,10 +13,17 @@ You may obtain a copy of the License at
     See the License for the specific language governing permissions and
     limitations under the License.
 #}
+{% if referring_node.batching.enabled %}
+    {%- set item_input = 'items' %}
+    {%- set name_input = 'batch_name' %}
+{% else %}
+    {%- set item_input = 'item' %}
+    {%- set name_input = 'item_name' %}
+{% endif %}
 def {{ generator_operator_name | sanitize_operator_name }}_builder(
         index,
-        item,
-        item_name,
+        {{ item_input }},
+        {{ name_input }},
         dag,
         upstream_dependencies,
         downstream_dependencies):

--- a/boundary_layer/registry/types/generator.py
+++ b/boundary_layer/registry/types/generator.py
@@ -28,6 +28,10 @@ class GeneratorNode(SubdagNode):
     def regex_blocklist(self):
         return self.item.get('regex_blocklist', ())
 
+    @property
+    def batching(self):
+        return self.item.get('batching', {'enabled': False, 'batch_size': 1})
+
 
 class GeneratorRegistry(ConfigFileRegistry):
     node_cls = GeneratorNode

--- a/boundary_layer/registry/types/generator.py
+++ b/boundary_layer/registry/types/generator.py
@@ -32,6 +32,10 @@ class GeneratorNode(SubdagNode):
     def batching(self):
         return self.item.get('batching', {})
 
+    @property
+    def batching_enabled(self):
+        return not self.batching.get('disabled') if self.batching else False
+
 
 class GeneratorRegistry(ConfigFileRegistry):
     node_cls = GeneratorNode

--- a/boundary_layer/registry/types/generator.py
+++ b/boundary_layer/registry/types/generator.py
@@ -30,7 +30,7 @@ class GeneratorNode(SubdagNode):
 
     @property
     def batching(self):
-        return self.item.get('batching', {'enabled': False, 'batch_size': 1})
+        return self.item.get('batching', {})
 
 
 class GeneratorRegistry(ConfigFileRegistry):

--- a/boundary_layer/registry/types/operator.py
+++ b/boundary_layer/registry/types/operator.py
@@ -422,7 +422,8 @@ class OperatorNode(RegistryNode):
             return base_name
 
         suffix_mode = execution_context.referrer.item.get('auto_task_id_mode')
-        name_var = 'batch_name' if execution_context.referrer.item.get('batching', {'enabled': False})['enabled'] else 'item_name'
+        batching_config = execution_context.referrer.item.get('batching', {'enabled': False})
+        name_var = 'batch_name' if batching_config['enabled'] else 'item_name'
         if not suffix_mode or suffix_mode == name_var:
             return base_name + '-<<' + name_var + '>>'
         elif suffix_mode == 'index':

--- a/boundary_layer/registry/types/operator.py
+++ b/boundary_layer/registry/types/operator.py
@@ -422,8 +422,9 @@ class OperatorNode(RegistryNode):
             return base_name
 
         suffix_mode = execution_context.referrer.item.get('auto_task_id_mode')
-        if not suffix_mode or suffix_mode == 'item_name':
-            return base_name + '-<<item_name>>'
+        name_var = 'batch_name' if execution_context.referrer.item.get('batching', {'enabled': False})['enabled'] else 'item_name'
+        if not suffix_mode or suffix_mode == name_var:
+            return base_name + '-<<' + name_var + '>>'
         elif suffix_mode == 'index':
             return base_name + '-<<str(index)>>'
 

--- a/boundary_layer/registry/types/operator.py
+++ b/boundary_layer/registry/types/operator.py
@@ -423,6 +423,14 @@ class OperatorNode(RegistryNode):
 
         suffix_mode = execution_context.referrer.item.get('auto_task_id_mode')
         batching_config = execution_context.referrer.item.get('batching', {'enabled': False})
+        # Validate suffix_mode based on batching config
+        if batching_config['enabled'] and suffix_mode == 'item_name':
+            raise Exception(
+                'Cannot use `item_name` for auto_task_id_mode when batching is enabled')
+        elif not batching_config['enabled'] and suffix_mode == 'batch_name':
+            raise Exception(
+                'Cannot use `batch_name` for auto_task_id_mode when batching is disabled')
+
         name_var = 'batch_name' if batching_config['enabled'] else 'item_name'
         if not suffix_mode or suffix_mode == name_var:
             return base_name + '-<<' + name_var + '>>'

--- a/boundary_layer/registry/types/operator.py
+++ b/boundary_layer/registry/types/operator.py
@@ -423,7 +423,7 @@ class OperatorNode(RegistryNode):
 
         suffix_mode = execution_context.referrer.item.get('auto_task_id_mode')
         batching_config = execution_context.referrer.item.get('batching', {})
-        batching_enabled = not batching_config.get('disabled') if len(batching_config) > 0 else False
+        batching_enabled = not batching_config.get('disabled') if batching_config else False
         # Validate suffix_mode based on batching config
         if batching_enabled and suffix_mode == 'item_name':
             raise Exception(

--- a/boundary_layer/registry/types/operator.py
+++ b/boundary_layer/registry/types/operator.py
@@ -422,8 +422,7 @@ class OperatorNode(RegistryNode):
             return base_name
 
         suffix_mode = execution_context.referrer.item.get('auto_task_id_mode')
-        batching_config = execution_context.referrer.item.get('batching', {})
-        batching_enabled = not batching_config.get('disabled') if batching_config else False
+        batching_enabled = execution_context.referrer.batching_enabled
         # Validate suffix_mode based on batching config
         if batching_enabled and suffix_mode == 'item_name':
             raise Exception(

--- a/boundary_layer/registry/types/operator.py
+++ b/boundary_layer/registry/types/operator.py
@@ -422,16 +422,17 @@ class OperatorNode(RegistryNode):
             return base_name
 
         suffix_mode = execution_context.referrer.item.get('auto_task_id_mode')
-        batching_config = execution_context.referrer.item.get('batching', {'enabled': False})
+        batching_config = execution_context.referrer.item.get('batching', {})
+        batching_enabled = not batching_config.get('disabled') if len(batching_config) > 0 else False
         # Validate suffix_mode based on batching config
-        if batching_config['enabled'] and suffix_mode == 'item_name':
+        if batching_enabled and suffix_mode == 'item_name':
             raise Exception(
                 'Cannot use `item_name` for auto_task_id_mode when batching is enabled')
-        elif not batching_config['enabled'] and suffix_mode == 'batch_name':
+        elif not batching_enabled and suffix_mode == 'batch_name':
             raise Exception(
                 'Cannot use `batch_name` for auto_task_id_mode when batching is disabled')
 
-        name_var = 'batch_name' if batching_config['enabled'] else 'item_name'
+        name_var = 'batch_name' if batching_enabled else 'item_name'
         if not suffix_mode or suffix_mode == name_var:
             return base_name + '-<<' + name_var + '>>'
         elif suffix_mode == 'index':

--- a/boundary_layer/schemas/dag.py
+++ b/boundary_layer/schemas/dag.py
@@ -14,7 +14,7 @@
 #     limitations under the License.
 
 import semver
-from marshmallow import fields, post_load, pre_dump, validates_schema, ValidationError
+from marshmallow import fields, validates_schema, ValidationError
 from boundary_layer import VERSION, MIN_SUPPORTED_VERSION
 from boundary_layer.schemas.base import StrictSchema
 
@@ -36,28 +36,8 @@ class ReferenceSchema(OperatorSchema):
 
 
 class BatchingSchema(StrictSchema):
-    enabled = fields.Boolean()
+    disabled = fields.Boolean()
     batch_size = fields.Integer(required=True)
-    # This is a "transient" field to help with implicit enablement behavior
-    original_enabled = fields.Boolean(load_only=True)
-
-    @post_load
-    def fix_enabled_pre_load(self, data):
-        """
-        If batching config is set at all, it's assumed to be enabled.
-        """
-        enabled = data.get('enabled', None)
-        data['original_enabled'] = enabled
-        if enabled is None:
-            data['enabled'] = True
-
-    @pre_dump
-    def fix_enabled_pre_dump(self, data):
-        """
-        Don't persist the enabled field if it wasn't explicitly configured.
-        """
-        if data['original_enabled'] is None:
-            del data['enabled']
 
 
 class GeneratorSchema(ReferenceSchema):

--- a/boundary_layer/schemas/dag.py
+++ b/boundary_layer/schemas/dag.py
@@ -35,9 +35,15 @@ class ReferenceSchema(OperatorSchema):
     target = fields.String(required=True)
 
 
+class BatchingSchema(StrictSchema):
+    enabled = fields.Boolean(required=True)
+    batch_size = fields.Integer(required=True)
+
+
 class GeneratorSchema(ReferenceSchema):
     auto_task_id_mode = fields.String()
     regex_blocklist = fields.List(fields.String())
+    batching = fields.Nested(BatchingSchema)
 
     @validates_schema
     def check_task_id_mode(self, data):

--- a/test/test_generators.py
+++ b/test/test_generators.py
@@ -1,6 +1,13 @@
-from boundary_layer.registry import NodeTypes
-from boundary_layer.containers import ExecutionContext
+import copy
+import re
+import yaml
+
 from boundary_layer import plugins
+from boundary_layer.builders import PrimaryDagBuilder
+from boundary_layer.containers import ExecutionContext
+from boundary_layer.registry import NodeTypes
+from boundary_layer.registry.types.generator import GeneratorNode
+from boundary_layer.schemas.internal.generators import GeneratorSpecSchema
 
 
 def test_default_param_filler():
@@ -25,3 +32,168 @@ def test_default_param_filler():
         'timeout_sec': 5,
         'headers': {}
     }
+
+
+_base_config = {
+    'name': 'test_generator',
+    'type': 'list_generator',
+    'target': 'some_target',
+    'properties': {
+        'items': ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+    }
+}
+
+gen_yaml = """
+name: list_generator
+iterator_builder_method_code: return items
+item_name_builder_code: return item
+parameters_jsonschema:
+    properties:
+        items:
+            type: array
+            items:
+                type: string
+    additionalProperties: false
+    required:
+        - items
+"""
+
+
+def _run_preamble_template_test(batching_conf):
+    builder = PrimaryDagBuilder(None, None, None, None)
+    template = builder.get_jinja_template('generator_preamble.j2')
+    node = copy.deepcopy(_base_config)
+    if batching_conf is not None:
+        node['batching'] = batching_conf
+
+    rendered = template.render(
+        generator_operator_name='foo',
+        referring_node=node
+    )
+
+    items_batch_name_regex = re.compile(r'\s+items,\s+batch_name,')
+    item_item_name_regex = re.compile(r'\s+item,\s+item_name,')
+
+    items_batch_name_match = items_batch_name_regex.search(rendered)
+    item_item_name_match = item_item_name_regex.search(rendered)
+
+    return items_batch_name_match, item_item_name_match
+
+
+def test_preamble_template_batching_enabled():
+    batching_conf = {'batch_size': 3}
+    items_batch_name_match, item_item_name_match = _run_preamble_template_test(batching_conf)
+
+    assert items_batch_name_match is not None
+    assert item_item_name_match is None
+
+
+def test_preamble_template_batching_disabled():
+    batching_conf = {'batch_size': 3, 'disabled': True}
+    items_batch_name_match, item_item_name_match = _run_preamble_template_test(batching_conf)
+
+    assert item_item_name_match is not None
+    assert items_batch_name_match is None
+
+
+def test_preamble_template_batching_undefined():
+    items_batch_name_match, item_item_name_match = _run_preamble_template_test(None)
+
+    assert item_item_name_match is not None
+    assert items_batch_name_match is None
+
+
+def _run_operator_template_test(batching_conf, valid_operator_registry):
+    builder = PrimaryDagBuilder(None, None, None, None)
+    template = builder.get_jinja_template('generator_operator.j2')
+    loaded = GeneratorSpecSchema().load(yaml.load(gen_yaml))
+    node_conf = copy.deepcopy(_base_config)
+    if batching_conf is not None:
+        node_conf['batching'] = batching_conf
+    node = GeneratorNode(config=loaded.data, item=node_conf)
+    node.resolve_properties(
+        execution_context=ExecutionContext(None, {}),
+        default_task_args={},
+        base_operator_loader=valid_operator_registry.get,
+        preprocessor_loader=None
+    )
+
+    rendered = template.render(
+        node=node,
+        upstream_dependencies='upstream_foo',
+        downstream_dependencies='downstream_bar'
+    )
+
+    item_name_builder_regex = re.compile(r'.*def %s_item_name_builder\(.*' % node.name)
+    batch_name_builder_regex = re.compile(r'.*def %s_batch_name_builder\(.*' % node.name)
+    filter_helper_regex = re.compile(r'.*def generator_helper_filter_with_blocklist\(.*')
+    grouped_helper_regex = re.compile(r'.*def generator_helper_grouped_list\(.*')
+    builder_invocation = r'\s+%s_builder\(\s+index = index,' % node.target
+    items_batch_name_regex = re.compile(
+        r'%s\s+items = items,\s+batch_name = batch_name,' % builder_invocation
+    )
+    item_item_name_regex = re.compile(
+        r'%s\s+item = item,\s+item_name = item_name,' % builder_invocation
+    )
+
+    return {
+        'item_name_builder': item_name_builder_regex.search(rendered),
+        'batch_name_builder': batch_name_builder_regex.search(rendered),
+        'filter_helper': filter_helper_regex.search(rendered),
+        'grouped_helper': grouped_helper_regex.search(rendered),
+        'items_batch_name': items_batch_name_regex.search(rendered),
+        'item_item_name': item_item_name_regex.search(rendered),
+    }
+
+
+def test_operator_template_batching_enabled(valid_operator_registry):
+    """
+    Should have:
+    - node.name_item_name_builder
+    - node.name_batch_name_builder
+    - generator_helper_filter_with_blocklist
+    - generator_helper_grouped_list
+    - items = items, batch_name = batch_name
+    """
+    batching_conf = {'batch_size': 3}
+    matches = _run_operator_template_test(batching_conf, valid_operator_registry)
+
+    assert matches['item_name_builder'] is not None
+    assert matches['batch_name_builder'] is not None
+    assert matches['filter_helper'] is not None
+    assert matches['grouped_helper'] is not None
+    assert matches['items_batch_name'] is not None
+    assert matches['item_item_name'] is None
+
+
+def test_operator_template_batching_disabled(valid_operator_registry):
+    """
+    Should have:
+    - node.name_item_name_builder
+    - item = item, item_name = item_name
+    """
+    batching_conf = {'batch_size': 3, 'disabled': True}
+    matches = _run_operator_template_test(batching_conf, valid_operator_registry)
+
+    assert matches['item_name_builder'] is not None
+    assert matches['batch_name_builder'] is None
+    assert matches['filter_helper'] is None
+    assert matches['grouped_helper'] is None
+    assert matches['items_batch_name'] is None
+    assert matches['item_item_name'] is not None
+
+
+def test_operator_template_batching_undefined(valid_operator_registry):
+    """
+    Should have:
+    - node.name_item_name_builder
+    - item = item, item_name = item_name
+    """
+    matches = _run_operator_template_test(None, valid_operator_registry)
+
+    assert matches['item_name_builder'] is not None
+    assert matches['batch_name_builder'] is None
+    assert matches['filter_helper'] is None
+    assert matches['grouped_helper'] is None
+    assert matches['items_batch_name'] is None
+    assert matches['item_item_name'] is not None

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -1,57 +1,65 @@
 from boundary_layer.schemas.dag import BatchingSchema
 
 
+_batching_schema = BatchingSchema()
+
+
+def _load_and_validate(data):
+    loaded = _batching_schema.load(data)
+    assert not loaded[1]
+
+    return loaded[0]
+
+
+def _dump_and_validate(data):
+    dumped = _batching_schema.dump(data)
+    assert not dumped[1]
+
+    return dumped[0]
+
+
 def test_batching_schema_implicit_enabled():
-    schema = BatchingSchema()
     data = {
         'batch_size': 10
     }
-    batching = schema.load(data)[0]
+    batching = _load_and_validate(data)
 
-    assert batching['enabled'] is True
+    assert 'disabled' not in batching
     assert batching['batch_size'] == 10
-    assert batching['original_enabled'] is None
 
-    dumped = schema.dump(batching)[0]
+    dumped = _dump_and_validate(batching)
 
-    assert 'enabled' not in dumped
+    assert 'disabled' not in dumped
     assert dumped['batch_size'] == 10
-    assert 'original_enabled' not in dumped
 
 
 def test_batching_schema_explicit_enabled():
-    schema = BatchingSchema()
     data = {
-        'enabled': True,
+        'disabled': False,
         'batch_size': 10
     }
-    batching = schema.load(data)[0]
+    batching = _load_and_validate(data)
 
-    assert batching['enabled'] is True
+    assert batching['disabled'] is False
     assert batching['batch_size'] == 10
-    assert batching['original_enabled'] is True
 
-    dumped = schema.dump(batching)[0]
+    dumped = _dump_and_validate(batching)
 
-    assert dumped['enabled'] is True
+    assert dumped['disabled'] is False
     assert dumped['batch_size'] == 10
-    assert 'original_enabled' not in dumped
 
 
 def test_batching_schema_disabled():
-    schema = BatchingSchema()
     data = {
-        'enabled': False,
+        'disabled': True,
         'batch_size': 10
     }
-    batching = schema.load(data)[0]
+    batching = _load_and_validate(data)
 
-    assert batching['enabled'] is False
+    assert batching['disabled'] is True
     assert batching['batch_size'] == 10
-    assert batching['original_enabled'] is False
 
-    dumped = schema.dump(batching)[0]
+    dumped = _dump_and_validate(batching)
 
-    assert dumped['enabled'] is False
+    assert dumped['disabled'] is True
     assert dumped['batch_size'] == 10
-    assert 'original_enabled' not in dumped

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -1,11 +1,13 @@
 from boundary_layer.schemas.dag import BatchingSchema
 
+# Tests for BatchingSchema
 
 _batching_schema = BatchingSchema()
 
 
 def _load_and_validate(data):
     loaded = _batching_schema.load(data)
+    # Assert no errors occurred
     assert not loaded[1]
 
     return loaded[0]
@@ -13,6 +15,7 @@ def _load_and_validate(data):
 
 def _dump_and_validate(data):
     dumped = _batching_schema.dump(data)
+    # Assert no errors occurred
     assert not dumped[1]
 
     return dumped[0]

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -1,0 +1,57 @@
+from boundary_layer.schemas.dag import BatchingSchema
+
+
+def test_batching_schema_implicit_enabled():
+    schema = BatchingSchema()
+    data = {
+        'batch_size': 10
+    }
+    batching = schema.load(data)[0]
+
+    assert batching['enabled'] is True
+    assert batching['batch_size'] == 10
+    assert batching['original_enabled'] is None
+
+    dumped = schema.dump(batching)[0]
+
+    assert 'enabled' not in dumped
+    assert dumped['batch_size'] == 10
+    assert 'original_enabled' not in dumped
+
+
+def test_batching_schema_explicit_enabled():
+    schema = BatchingSchema()
+    data = {
+        'enabled': True,
+        'batch_size': 10
+    }
+    batching = schema.load(data)[0]
+
+    assert batching['enabled'] is True
+    assert batching['batch_size'] == 10
+    assert batching['original_enabled'] is True
+
+    dumped = schema.dump(batching)[0]
+
+    assert dumped['enabled'] is True
+    assert dumped['batch_size'] == 10
+    assert 'original_enabled' not in dumped
+
+
+def test_batching_schema_disabled():
+    schema = BatchingSchema()
+    data = {
+        'enabled': False,
+        'batch_size': 10
+    }
+    batching = schema.load(data)[0]
+
+    assert batching['enabled'] is False
+    assert batching['batch_size'] == 10
+    assert batching['original_enabled'] is False
+
+    dumped = schema.dump(batching)[0]
+
+    assert dumped['enabled'] is False
+    assert dumped['batch_size'] == 10
+    assert 'original_enabled' not in dumped


### PR DESCRIPTION
This pull request adds batching support to the generator framework (issue #13).  To enable batching in a generator, users can simply add a block like this to their generator's configuration:
```yaml
batching:
  batch_size: 5
```

If this configuration exists, batching is assumed to be desired.  If for some reason a user doesn't want to remove the batching configuration, but doesn't want to actually use it (for example, during development etc.), `disabled: true` can be added to fall back to the original non-batching generator flow.