### PR TITLE
Ignore Vim swap files when loading registry

### DIFF
--- a/boundary_layer/registry/registry.py
+++ b/boundary_layer/registry/registry.py
@@ -197,6 +197,10 @@ class ConfigFileRegistry(Registry):
         for path in config_paths:
             logger.debug('Loading configs from path %s', path)
             for filename in os.listdir(path):
+                # Skip Vim swap files (for local development)
+                if os.path.splitext(filename)[1] in ['.swp', '.swo']:
+                    continue
+
                 full_path = os.path.abspath(os.path.join(path, filename))
 
                 if os.path.splitext(filename)[1] not in ['.yaml', '.yml']:


### PR DESCRIPTION
This PR simply allows registry config files to be open in Vim while running `boundary-layer`, to support rapid development.

To reproduce the failure case, just open a config file (e.g. `boundary_layer_default_plugin/config/operators/base.yaml`) with Vim and try to run `boundary-layer build-dag ...`.  This should fail with a complaint about an invalid file being found.