### PR TITLE
Create a generator for lists of files in GCS

### DIFF
--- a/boundary_layer_default_plugin/config/generators/gcs_list_generator.yaml
+++ b/boundary_layer_default_plugin/config/generators/gcs_list_generator.yaml
@@ -1,0 +1,36 @@
+# Copyright 2018 Etsy Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+name: gcs_list_generator
+# TODO: Support `delimiter` argument once Airflow 1.10 is supported
+iterator_builder_method_code: |
+    return GoogleCloudStorageHook().list(
+            bucket,
+            prefix = prefix)
+item_name_builder_code: return item
+imports:
+    objects:
+        - module: airflow.contrib.hooks.gcs_hook
+          objects:
+              - GoogleCloudStorageHook
+parameters_jsonschema:
+    properties:
+        bucket:
+            type: string
+        prefix:
+            type: string
+    additionalProperties: false
+    required:
+        - bucket
+


### PR DESCRIPTION
Similar to the existing `list_generator`, this PR adds a new generator that allows for iteration over a set of files in Google Cloud Storage.  It uses existing GCS hook functionality to get a list of files by bucket and prefix.