### PR TITLE
Skip `EnsureRenderedStringPattern` preprocessor if parameter has verbatim directives

### DIFF
--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -110,6 +110,14 @@ class EnsureRenderedStringPattern(PropertyPreprocessor):
                 regex.pattern)
             return arg
 
+        VERBATIM_REGEX = '<<item_name>>|<<item.name>>|<<item.value>>'
+        if re.compile(VERBATIM_REGEX).search(rendered_arg):
+            logger.warning(
+                'Argument generated from `%s` may not match the required pattern `%s` and fail.',
+                rendered_arg,
+                regex.pattern)
+            return arg
+
         if not regex.match(rendered_arg):
             raise Exception(
                 'Invalid argument `{}`: does not match expected pattern `{}`'.format(

--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -110,7 +110,12 @@ class EnsureRenderedStringPattern(PropertyPreprocessor):
                 regex.pattern)
             return arg
 
-        VERBATIM_REGEX = '<<item_name>>|<<item.name>>|<<item.value>>'
+        if regex.match(rendered_arg):
+            # return the original arg, not the rendered arg, because we are not
+            # actually transforming anything, just validating
+            return arg
+
+        VERBATIM_REGEX = '<<.+>>'
         if re.compile(VERBATIM_REGEX).search(rendered_arg):
             logger.warning(
                 'Argument generated from `%s` may not match the required pattern `%s` and fail.',
@@ -118,15 +123,10 @@ class EnsureRenderedStringPattern(PropertyPreprocessor):
                 regex.pattern)
             return arg
 
-        if not regex.match(rendered_arg):
-            raise Exception(
-                'Invalid argument `{}`: does not match expected pattern `{}`'.format(
-                    rendered_arg,
-                    regex.pattern))
-
-        # return the original arg, not the rendered arg, because we are not
-        # actually transforming anything, just validating
-        return arg
+        raise Exception(
+            'Invalid argument `{}`: does not match expected pattern `{}`'.format(
+                rendered_arg,
+                regex.pattern))
 
     @property
     def pattern(self):

--- a/test/default_plugin/test_preprocessors.py
+++ b/test/default_plugin/test_preprocessors.py
@@ -32,6 +32,21 @@ def test_ensure_rendered_string_pattern(mocker):
     ) == "my-cluster-{{unknown_var.task_id}}"
     warning_mock.assert_called_once()
 
+
+    warning_mock = Mock()
+    mocker.patch.object(logger, 'warning', new=warning_mock)
+    assert renderer.process_arg(
+        "my-<<item_name>>-cluster", None, {},
+    ) == "my-<<item_name>>-cluster"
+    warning_mock.assert_called_once()
+
+    warning_mock = Mock()
+    mocker.patch.object(logger, 'warning', new=warning_mock)
+    assert renderer.process_arg(
+        "my-cluster-<<item.value>>", None, {},
+    ) == "my-cluster-<<item.value>>"
+    warning_mock.assert_called_once()
+
     with pytest.raises(Exception):
         renderer.process_arg("my-cluster-", None, {})
 
@@ -46,3 +61,6 @@ def test_ensure_rendered_string_pattern(mocker):
             "my-cluster-{{execution_date.strftime('%Y_%m_%d')}}",
             None,
             {})
+
+    with pytest.raises(Exception):
+        renderer.process_arg("My-<<non-item.value>>-cluster", None, {})

--- a/test/default_plugin/test_preprocessors.py
+++ b/test/default_plugin/test_preprocessors.py
@@ -63,4 +63,4 @@ def test_ensure_rendered_string_pattern(mocker):
             {})
 
     with pytest.raises(Exception):
-        renderer.process_arg("My-<<non-item.value>>-cluster", None, {})
+        renderer.process_arg("My-<item.value>-cluster", None, {})


### PR DESCRIPTION
* Log warning message instead