### PR TITLE
Plugin error-handling fix

### DIFF
--- a/boundary_layer/plugins/plugin_manager.py
+++ b/boundary_layer/plugins/plugin_manager.py
@@ -189,11 +189,12 @@ class PluginManager(object):
                 if registry_getter(plugin)
                 for node_type in registry_getter(plugin).node_configs)
             raise Exception(
-                'Registry entry type `{}` not found for item `{}`. '
-                'Available types are: {}'.format(
+                'Lookup failed for registry `{}`: `{}` not found for item `{}`. '
+                'Available item types are: [`{}`]'.format(
+                    registry_name,
                     item['type'],
                     item,
-                    available_types))
+                    '`, `'.join(available_types)))
 
         highest_hit_priority = max(
             prioritized_hits.keys(),

--- a/boundary_layer/plugins/plugin_manager.py
+++ b/boundary_layer/plugins/plugin_manager.py
@@ -186,6 +186,7 @@ class PluginManager(object):
         if not prioritized_hits:
             available_types = frozenset(
                 node_type for plugin in self._plugins
+                if registry_getter(plugin)
                 for node_type in registry_getter(plugin).node_configs)
             raise Exception(
                 'Registry entry type `{}` not found for item `{}`. '


### PR DESCRIPTION
This commit fixes a failure that occurs during an error-handling condition, caused by the combination of:
 - a workflow containing an object with an invalid name, and
 - the presence of a boundary-layer plugin that does not implement all registry types

The error manifests itself with the error message
```
AttributeError: 'NoneType' object has no attribute 'node_configs'
```
which is very opaque.

After the fix, the message is a much more readable one:
```
Exception: Lookup failed for registry `resource`: `bash-operator` not found for item `{'type': u'bash-operator', 'name': u'hi'}`. Available item types are: [`dataproc_cluster`]
```