### PR TITLE
Changed the package_uris type to list in cmle_training_operator

### DIFF
--- a/boundary_layer_default_plugin/config/operators/ml_engine_training.yaml
+++ b/boundary_layer_default_plugin/config/operators/ml_engine_training.yaml
@@ -24,7 +24,9 @@ parameters_jsonschema:
         job_id:
             type: string
         package_uris:
-            type: string
+            type:array
+            items:
+                type: string
         training_python_module:
             type: string
         training_args:

--- a/boundary_layer_default_plugin/config/operators/ml_engine_training.yaml
+++ b/boundary_layer_default_plugin/config/operators/ml_engine_training.yaml
@@ -24,7 +24,7 @@ parameters_jsonschema:
         job_id:
             type: string
         package_uris:
-            type:array
+            type: array
             items:
                 type: string
         training_python_module:


### PR DESCRIPTION
This PR address the `package_uris` field type. The actual operator expects the list of strings https://github.com/apache/airflow/blob/master/airflow/contrib/operators/mlengine_operator.py#L456
However, the doc string indicates `string` which is confusing.