### PR TITLE
use yaml.safe_load instead of yaml.load

### DIFF
--- a/boundary_layer/registry/registry.py
+++ b/boundary_layer/registry/registry.py
@@ -173,7 +173,7 @@ class ConfigFileRegistry(Registry):
     def load_from_file(self, filename):
         item = None
         with open(filename) as _in:
-            item = yaml.load(_in)
+            item = yaml.safe_load(_in)
 
         logger.debug('validating item %s against schema %s',
                      item, self.spec_schema_cls.__name__)

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -31,7 +31,7 @@ class MockNode(RegistryNode):
     type = NodeTypes.OPERATOR
 
     def __init__(self, item):
-        mock_config = yaml.load(MOCK_NODE_CONFIG_YAML)
+        mock_config = yaml.safe_load(MOCK_NODE_CONFIG_YAML)
         super(MockNode, self).__init__(mock_config, item)
 
 


### PR DESCRIPTION
Switch to using `safe_load` for yaml loader, to suppress (and address) security warning.