### PR TITLE
remove python 3.4 tests due to repeated false failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
           env: TOXENV=py27
         - python: 2.7
           env: TOXENV=lint
-        - python: 3.4
-          env: TOXENV=py3
         - python: 3.5
           env: TOXENV=py3
         - python: 3.6


### PR DESCRIPTION
Travis's python 3.4 build has a very high failure rate due to errors on initialization.  Let's just get rid of it.