### PR TITLE
revert change of priority_weight type from string to int

### DIFF
--- a/boundary_layer_default_plugin/config/operators/base.yaml
+++ b/boundary_layer_default_plugin/config/operators/base.yaml
@@ -46,7 +46,7 @@ parameters_jsonschema:
         queue:
             type: string
         priority_weight:
-            type: integer
+            type: string
         weight_rule:
             type: string
         pool:


### PR DESCRIPTION
This reverts a small portion of the changes from #34 : in particular, the change of the data type for `priority_weight` from `string` to `int`.  This change caused failures internal to Etsy in places where we use verbatim strings to compute priority weights dynamically based on task id's.

(This change slipped by because it was not marked as a deletion in the pull request, due to the addition of an adjacent field of type `string` that caused the change to look like an addition).