### PR TITLE
[BREAKING CHANGE] Conform to parameter requirements for gcs_to_bigquery in 1.10.3

### DIFF
--- a/boundary_layer_default_plugin/config/operators/gcs_to_bigquery.yaml
+++ b/boundary_layer_default_plugin/config/operators/gcs_to_bigquery.yaml
@@ -84,6 +84,13 @@ parameters_jsonschema:
                 type: string
         autodetect:
             type: boolean
+        oneOf:
+            - required:
+                - autodetect
+            - required:
+                - schema_object
+            - required:
+                - schema_fields
 
     required:
         - bucket

--- a/boundary_layer_default_plugin/config/operators/gcs_to_bigquery.yaml
+++ b/boundary_layer_default_plugin/config/operators/gcs_to_bigquery.yaml
@@ -84,13 +84,13 @@ parameters_jsonschema:
                 type: string
         autodetect:
             type: boolean
-        oneOf:
-            - required:
-                - autodetect
-            - required:
-                - schema_object
-            - required:
-                - schema_fields
+      oneOf:
+          - required:
+              - autodetect
+          - required:
+              - schema_object
+          - required:
+              - schema_fields
 
     required:
         - bucket


### PR DESCRIPTION
In Airflow 1.10.3 one of `schema_fields`, `schema_object`, or `autodetect` must be specified.  See:
https://github.com/apache/airflow/blob/1.10.3/airflow/contrib/operators/gcs_to_bq.py#L217-L218

Obviously this is a breaking change and should wait for the appropriate boundary-layer release, but putting here in advance of that and to make the issue visible.

