### PR TITLE
Change NetworkX dependency to stay with python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
         'jinja2>=2.8.1,<3.0',
         'pyyaml>=4.2b1',
         'marshmallow>=2.13.6,<3.0',
-        'networkx>=2.1,<3.0',
+        'networkx>=2.1,<2.3',
         'xmltodict>=0.11.0,<1.0',
         'six>=1.11.0,<2.0',
     ],


### PR DESCRIPTION
NetworkX 2.3 is python3 only (https://networkx.github.io/documentation/stable/news.html#networkx-2-3) so we can not pull that in and maintain python2 support.