### PR TITLE
update gcs_object_sensor to extend base_sensor

### DIFF
--- a/boundary_layer_default_plugin/config/operators/gcs_object_sensor.yaml
+++ b/boundary_layer_default_plugin/config/operators/gcs_object_sensor.yaml
@@ -15,7 +15,7 @@
 name: gcs_object_sensor
 operator_class: GoogleCloudStorageObjectSensor
 operator_class_module: airflow.contrib.sensors.gcs_sensor
-schema_extends: base
+schema_extends: base_sensor
 parameters_jsonschema:
     properties:
         bucket:


### PR DESCRIPTION
GCS object sensor fails when adding the `mode: reschedule` parameter. @dossett - pointed out that the sensor currently extends `base`, but should be extending `base_sensor` instead which is where the reschedule mode is picked up. `base_sensor` in itself extends `base` so this should not break anything and aligns with other sensor configurations such as `external_task_sensor.yaml`.