### PR TITLE
Addition of BigQueryOperator and BigQueryToCloudStorageOperator

### DIFF
--- a/boundary_layer_default_plugin/config/operators/bigquery_operator.yaml
+++ b/boundary_layer_default_plugin/config/operators/bigquery_operator.yaml
@@ -20,7 +20,7 @@ operator_class_module: airflow.contrib.operators.bigquery_operator
 schema_extends: base
 parameters_jsonschema:
     properties:
-        sql:
+    	sql:
 			type: string
 		destination_dataset_table:
 			type: string

--- a/boundary_layer_default_plugin/config/operators/bigquery_operator.yaml
+++ b/boundary_layer_default_plugin/config/operators/bigquery_operator.yaml
@@ -45,17 +45,25 @@ parameters_jsonschema:
         maximum_bytes_billed:
             type: number
         api_resource_configs:
-            type: dict
+            type: object
+            additionalProperties:
+                type: string
         schema_update_options:
             type: object
+            additionalProperties:
+                type: string
         query_params:
             type: array
         labels:
-            type: dict
+            type: object
+            additionalProperties:
+                type: string
         priority:
             type: string
         time_partitioning:
-            type: dict
+            type: object
+            additionalProperties:
+                type: string
         cluster_fields:
             type: array
             items:

--- a/boundary_layer_default_plugin/config/operators/bigquery_operator.yaml
+++ b/boundary_layer_default_plugin/config/operators/bigquery_operator.yaml
@@ -1,0 +1,68 @@
+# Copyright 2018 Etsy Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+# see: https://github.com/apache/airflow/blob/1.10.3/airflow/contrib/operators/bigquery_operator.py
+
+name: bigquery_operator
+operator_class: BigQueryOperator
+operator_class_module: airflow.contrib.operators.bigquery_operator 
+schema_extends: base
+parameters_jsonschema:
+    properties:
+        sql:
+			type: string
+		destination_dataset_table:
+			type: string
+		write_disposition:
+			type: string
+		create_disposition:
+			type: string
+		allow_large_results:
+			type: boolean
+		flatten_results:
+			type: boolean
+		bigquery_conn_id:
+			type: string
+		delegate_to:
+			type: string
+		udf_config:
+			type: array
+		use_legacy_sql:
+			type: boolean
+		maximum_billing_tier:
+			type: integer
+		maximum_bytes_billed:
+			type: number
+		api_resource_configs:
+			type: dict
+		schema_update_options:
+			type: object
+		query_params:
+			type: array
+		labels:
+			type: dict
+		priority:
+			type: string
+		time_partitioning:
+			type: dict
+		cluster_fields:
+			type: array
+            items:
+                type: string
+		location:
+			type: string
+
+    required:
+        - sql
+        - destination_dataset_table

--- a/boundary_layer_default_plugin/config/operators/bigquery_operator.yaml
+++ b/boundary_layer_default_plugin/config/operators/bigquery_operator.yaml
@@ -20,48 +20,48 @@ operator_class_module: airflow.contrib.operators.bigquery_operator
 schema_extends: base
 parameters_jsonschema:
     properties:
-    	sql:
-			type: string
-		destination_dataset_table:
-			type: string
-		write_disposition:
-			type: string
-		create_disposition:
-			type: string
-		allow_large_results:
-			type: boolean
-		flatten_results:
-			type: boolean
-		bigquery_conn_id:
-			type: string
-		delegate_to:
-			type: string
-		udf_config:
-			type: array
-		use_legacy_sql:
-			type: boolean
-		maximum_billing_tier:
-			type: integer
-		maximum_bytes_billed:
-			type: number
-		api_resource_configs:
-			type: dict
-		schema_update_options:
-			type: object
-		query_params:
-			type: array
-		labels:
-			type: dict
-		priority:
-			type: string
-		time_partitioning:
-			type: dict
-		cluster_fields:
-			type: array
+        sql:
+            type: string
+        destination_dataset_table:
+            type: string
+        write_disposition:
+            type: string
+        create_disposition:
+            type: string
+        allow_large_results:
+            type: boolean
+        flatten_results:
+            type: boolean
+        bigquery_conn_id:
+            type: string
+        delegate_to:
+            type: string
+        udf_config:
+            type: array
+        use_legacy_sql:
+            type: boolean
+        maximum_billing_tier:
+            type: integer
+        maximum_bytes_billed:
+            type: number
+        api_resource_configs:
+            type: dict
+        schema_update_options:
+            type: object
+        query_params:
+            type: array
+        labels:
+            type: dict
+        priority:
+            type: string
+        time_partitioning:
+            type: dict
+        cluster_fields:
+            type: array
             items:
                 type: string
-		location:
-			type: string
+        location:
+            type: string
 
     required:
         - sql

--- a/boundary_layer_default_plugin/config/operators/bigquery_to_gcs.yaml
+++ b/boundary_layer_default_plugin/config/operators/bigquery_to_gcs.yaml
@@ -21,7 +21,7 @@ schema_extends: base
 parameters_jsonschema:
     properties:
         source_project_dataset_table:
-			      type: string
+            type: string
         destination_cloud_storage_uris:
             type: array
         compression:
@@ -38,7 +38,7 @@ parameters_jsonschema:
             type: string
         labels:
             type: dict
-		
+
     required:
         - source_project_dataset_table
         - destination_cloud_storage_uris

--- a/boundary_layer_default_plugin/config/operators/bigquery_to_gcs.yaml
+++ b/boundary_layer_default_plugin/config/operators/bigquery_to_gcs.yaml
@@ -37,7 +37,9 @@ parameters_jsonschema:
         delegate_to:
             type: string
         labels:
-            type: dict
+            type: object
+            additionalProperties:
+                type: string
 
     required:
         - source_project_dataset_table

--- a/boundary_layer_default_plugin/config/operators/bigquery_to_gcs.yaml
+++ b/boundary_layer_default_plugin/config/operators/bigquery_to_gcs.yaml
@@ -20,24 +20,24 @@ operator_class_module: airflow.contrib.operators.bigquery_to_gcs
 schema_extends: base
 parameters_jsonschema:
     properties:
-    	source_project_dataset_table:
-			type: string
-		destination_cloud_storage_uris:
-			type: array
-		compression:
-			type: string
-		export_format:
-			type: string
-		field_delimiter:
-			type: string
-		print_header:
-			type: boolean
-		bigquery_conn_id:
-			type: string
-		delegate_to:
-			type: string
-		labels:
-			type: dict
+        source_project_dataset_table:
+			      type: string
+        destination_cloud_storage_uris:
+            type: array
+        compression:
+            type: string
+        export_format:
+            type: string
+        field_delimiter:
+            type: string
+        print_header:
+            type: boolean
+        bigquery_conn_id:
+            type: string
+        delegate_to:
+            type: string
+        labels:
+            type: dict
 		
     required:
         - source_project_dataset_table

--- a/boundary_layer_default_plugin/config/operators/bigquery_to_gcs.yaml
+++ b/boundary_layer_default_plugin/config/operators/bigquery_to_gcs.yaml
@@ -1,0 +1,44 @@
+# Copyright 2018 Etsy Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+# see: https://github.com/apache/airflow/blob/1.10.3/airflow/contrib/operators/bigquery_to_gcs.py
+
+name: bigquery_to_gcs
+operator_class: BigQueryToCloudStorageOperator
+operator_class_module: airflow.contrib.operators.bigquery_to_gcs 
+schema_extends: base
+parameters_jsonschema:
+    properties:
+    	source_project_dataset_table:
+			type: string
+		destination_cloud_storage_uris:
+			type: array
+		compression:
+			type: string
+		export_format:
+			type: string
+		field_delimiter:
+			type: string
+		print_header:
+			type: boolean
+		bigquery_conn_id:
+			type: string
+		delegate_to:
+			type: string
+		labels:
+			type: dict
+		
+    required:
+        - source_project_dataset_table
+        - destination_cloud_storage_uris


### PR DESCRIPTION
I added two standard Airflow operators to enable BigQuery queries and BigQuery to GCS functionality. 