### PR TITLE
Add http_operator to supported operators

### DIFF
--- a/boundary_layer_default_plugin/config/operators/http_operator.yaml
+++ b/boundary_layer_default_plugin/config/operators/http_operator.yaml
@@ -1,0 +1,57 @@
+# Copyright 2018 Etsy Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+# see: https://github.com/apache/airflow/blob/1.10.3/airflow/operators/http_operator.py
+name: http_operator
+operator_class: SimpleHttpOperator
+operator_class_module: airflow.operators.http_operator
+schema_extends: base
+parameters_jsonschema:
+    properties:
+        endpoint:
+            type: string
+        method:
+            type: string
+            enum:
+                - POST
+                - GET
+                - PUT
+                - PATCH
+                - DELETE
+        data:
+            type: object
+            additionalProperties:
+                type:
+                    string
+        headers:
+            type: object
+            additionalProperties:
+                type:
+                    string
+        response_check:
+            type: string
+        extra_options:
+            type: object
+            additionalProperties:
+                type:
+                    string
+        xcom_push:
+            type: boolean
+        http_conn_id:
+            type: string
+        log_response:
+            type: boolean
+    required:
+        - endpoint
+    additionalProperties: false


### PR DESCRIPTION
This adds support for the SimpleHttpOperator's use in boundary layer:

https://github.com/apache/airflow/blob/1.10.3/airflow/operators/http_operator.py