### PR TITLE
Don't include enum34 for py3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         },
     extras_require = extras,
     install_requires = [
-        'enum34>=1.1.6,<2.0',
+        'enum34>=1.1.6,<2.0;python_version<"3.4"',
         'semver>=2.7.0,<3.0',
         'jsonschema>=2.6.0,<3.0',
         'jinja2>=2.8.1,<3.0',


### PR DESCRIPTION
`enum34` isn't meant for python >= 3.4 and including it in our dependencies can sometimes cause issues