### PR TITLE
Fix priority weight type

### DIFF
--- a/boundary_layer_default_plugin/config/operators/base.yaml
+++ b/boundary_layer_default_plugin/config/operators/base.yaml
@@ -46,7 +46,7 @@ parameters_jsonschema:
         queue:
             type: string
         priority_weight:
-            type: string
+            type: integer
         weight_rule:
             type: string
         pool:

--- a/test/data/registry/invalid-bad-config/operators/base.yaml
+++ b/test/data/registry/invalid-bad-config/operators/base.yaml
@@ -46,7 +46,7 @@ parameters_jsonschema:
         queue:
             type: string
         priority_weight:
-            type: string
+            type: integer
         pool:
             type: string
         sla:

--- a/test/data/registry/invalid-duplicate-names/operators/base.yaml
+++ b/test/data/registry/invalid-duplicate-names/operators/base.yaml
@@ -46,7 +46,7 @@ parameters_jsonschema:
         queue:
             type: string
         priority_weight:
-            type: string
+            type: integer
         pool:
             type: string
         sla:

--- a/test/data/registry/valid/operators/base.yaml
+++ b/test/data/registry/valid/operators/base.yaml
@@ -46,7 +46,7 @@ parameters_jsonschema:
         queue:
             type: string
         priority_weight:
-            type: string
+            type: integer
         pool:
             type: string
         sla:


### PR DESCRIPTION
One of the teams ran into an issue while testing this parameter. From the docs, the parameter priority_weight should accept an integer.

https://airflow.apache.org/docs/stable/_api/airflow/operators/index.html

Tests:
```
[boundary-layer (vchiapaikeo/fix-priority-weight-v1)]> tox --recreate test/
GLOB sdist-make: /Users/vchiapaikeo/development/boundary-layer/setup.py
py27 recreate: /Users/vchiapaikeo/development/boundary-layer/.tox/py27
py27 installdeps: pytest==3.8.1, pytest-cov==2.6.0, pytest-mock==1.10.0, pylint==1.9.3, pycodestyle==2.4.0, mock==2.0.0
py27 inst: /Users/vchiapaikeo/development/boundary-layer/.tox/.tmp/package/1/boundary-layer-1.7.10.dev0.zip
py27 installed: DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support,astroid==1.6.6,atomicwrites==1.3.0,attrs==19.3.0,backports.functools-lru-cache==1.6.1,boundary-layer==1.7.10.dev0,certifi==2020.4.5.1,cffi==1.14.0,chardet==3.0.4,configparser==4.0.2,contextlib2==0.6.0.post1,coverage==5.1,cryptography==2.9.2,decorator==4.4.2,enum34==1.1.10,funcsigs==1.0.2,functools32==3.2.3.post2,futures==3.3.0,github3.py==1.3.0,idna==2.9,importlib-metadata==1.6.0,ipaddress==1.0.23,isort==4.3.21,Jinja2==2.11.2,jsonschema==2.6.0,jwcrypto==0.7,lazy-object-proxy==1.4.3,MarkupSafe==1.1.1,marshmallow==2.21.0,mccabe==0.6.1,mock==2.0.0,more-itertools==5.0.0,networkx==2.2,pathlib2==2.3.5,pbr==5.4.5,pluggy==0.13.1,py==1.8.1,pycodestyle==2.4.0,pycparser==2.20,pylint==1.9.3,pytest==3.8.1,pytest-cov==2.6.0,pytest-mock==1.10.0,python-dateutil==2.8.1,PyYAML==5.3.1,requests==2.23.0,scandir==1.10.0,semver==2.9.1,singledispatch==3.4.0.3,six==1.14.0,uritemplate==3.0.1,urllib3==1.25.9,wrapt==1.12.1,xmltodict==0.12.0,zipp==1.2.0
py27 run-test-pre: PYTHONHASHSEED='2450988460'
py27 run-test: commands[0] | pytest -vv --cov-config=tox.ini --cov=boundary_layer --cov=boundary_layer_default_plugin --cov-report=term-missing --cov-report=xml test
===================================================================================== test session starts =====================================================================================
platform darwin -- Python 2.7.16, pytest-3.8.1, py-1.8.1, pluggy-0.13.1 -- /Users/vchiapaikeo/development/boundary-layer/.tox/py27/bin/python
cachedir: .pytest_cache
rootdir: /Users/vchiapaikeo/development/boundary-layer, inifile:
plugins: mock-1.10.0, cov-2.6.0
collected 59 items                                                                                                                                                                            

test/test_generators.py::test_default_param_filler PASSED                                                                                                                               [  1%]
test/test_graph.py::test_node_comparison PASSED                                                                                                                                         [  3%]
test/test_graph.py::test_graph_builder PASSED                                                                                                                                           [  5%]
test/test_graph.py::test_invalid_upstream_ref PASSED                                                                                                                                    [  6%]
test/test_graph.py::test_invalid_downstream_ref PASSED                                                                                                                                  [  8%]
test/test_graph.py::test_cycle_detector PASSED                                                                                                                                          [ 10%]
test/test_graph.py::test_boundary_extractor PASSED                                                                                                                                      [ 11%]
test/test_graph.py::test_orderer PASSED                                                                                                                                                 [ 13%]
test/test_graph.py::test_dependency_set_computations PASSED                                                                                                                             [ 15%]
test/test_graph.py::test_flow_control_inserter_auto_fc_node PASSED                                                                                                                      [ 16%]
test/test_graph.py::test_flow_control_inserter PASSED                                                                                                                                   [ 18%]
test/test_graph.py::test_flow_control_inserter_invalid_args PASSED                                                                                                                      [ 20%]
test/test_graph.py::test_resource_boundaries PASSED                                                                                                                                     [ 22%]
test/test_graph.py::test_bundler_inserter PASSED                                                                                                                                        [ 23%]
test/test_graph.py::test_default_bundler_inserter PASSED                                                                                                                                [ 25%]
test/test_graph.py::test_attach_create_resource PASSED                                                                                                                                  [ 27%]
test/test_graph.py::test_attach_destroy_resource PASSED                                                                                                                                 [ 28%]
test/test_graph.py::test_attach_destroy_resource_no_sentinel_by_config PASSED                                                                                                           [ 30%]
test/test_graph.py::test_attach_destroy_resource_no_sentinel_because_other_leaf_nodes PASSED                                                                                            [ 32%]
test/test_graph.py::test_prune_node PASSED                                                                                                                                              [ 33%]
test/test_graph.py::test_prune_nodes PASSED                                                                                                                                             [ 35%]
test/test_workflow.py::test_parse_workflow_with_resources PASSED                                                                                                                        [ 37%]
test/test_workflow.py::test_parse_workflow_with_subdag PASSED                                                                                                                           [ 38%]
test/test_workflow.py::test_parse_workflow_with_generator PASSED                                                                                                                        [ 40%]
test/test_workflow.py::test_parse_workflow_with_multiple_generators PASSED                                                                                                              [ 42%]
test/test_workflow.py::test_parse_invalid_workflows PASSED                                                                                                                              [ 44%]
test/test_workflow.py::test_build_referrer_map PASSED                                                                                                                                   [ 45%]
test/test_workflow.py::test_node_path_builder PASSED                                                                                                                                    [ 47%]
test/test_workflow.py::test_invalid_node_reference_errors PASSED                                                                                                                        [ 49%]
test/test_workflow.py::test_node_path_partitioner PASSED                                                                                                                                [ 50%]
test/test_workflow.py::test_workflow_prune PASSED                                                                                                                                       [ 52%]
test/test_workflow.py::test_workflow_prune_only_nodes PASSED                                                                                                                            [ 54%]
test/test_workflow.py::test_workflow_prune_resulting_in_unreachable PASSED                                                                                                              [ 55%]
test/test_workflow.py::test_only_subdag_operator_includes_sub_workflow PASSED                                                                                                           [ 57%]
test/builders/test_util.py::test_sanitize_operator_name PASSED                                                                                                                          [ 59%]
test/builders/test_util.py::test_verbatim PASSED                                                                                                                                        [ 61%]
test/builders/test_util.py::test_construct_dag_name PASSED                                                                                                                              [ 62%]
test/builders/test_util.py::test_subdag_builder_name PASSED                                                                                                                             [ 64%]
test/builders/test_util.py::test_add_leading_spaces PASSED                                                                                                                              [ 66%]
test/builders/test_util.py::test_enquote PASSED                                                                                                                                         [ 67%]
test/builders/test_util.py::test_split_verbatim PASSED                                                                                                                                  [ 69%]
test/builders/test_util.py::test_format_value PASSED                                                                                                                                    [ 71%]
test/builders/test_util.py::test_comment PASSED                                                                                                                                         [ 72%]
test/default_plugin/test_plugin.py::test_valid_plugin PASSED                                                                                                                            [ 74%]
test/default_plugin/test_preprocessors.py::test_ensure_rendered_string_pattern PASSED                                                                                                   [ 76%]
test/oozier/test_jsp_translator.py::test_macro_translator PASSED                                                                                                                        [ 77%]
test/oozier/test_jsp_translator.py::test_macro_translator_unknown_macro PASSED                                                                                                          [ 79%]
test/oozier/test_jsp_translator.py::test_macro_translator_unknown_input_type PASSED                                                                                                     [ 81%]
test/oozier/test_oozie_converter.py::test_workflow_parser PASSED                                                                                                                        [ 83%]
test/oozier/test_oozie_converter.py::test_workflow_parser_with_prune_forks PASSED                                                                                                       [ 84%]
test/plugins/test_plugin_manager.py::test_plugin_manager_default PASSED                                                                                                                 [ 86%]
test/plugins/test_plugin_manager.py::test_plugin_manager_multiple_priorities PASSED                                                                                                     [ 88%]
test/plugins/test_plugin_manager.py::test_plugin_manager_duplicate_priorities PASSED                                                                                                    [ 89%]
test/registry/types/test_operator_registry.py::test_operator_registry PASSED                                                                                                            [ 91%]
test/registry/types/test_operator_registry.py::test_reject_unknown_properties PASSED                                                                                                    [ 93%]
test/registry/types/test_operator_registry.py::test_accept_unknown_properties_for_flexible_schema PASSED                                                                                [ 94%]
test/registry/types/test_operator_registry.py::test_fail_on_missing_preprocessor PASSED                                                                                                 [ 96%]
test/registry/types/test_operator_registry.py::test_detect_duplicate_names PASSED                                                                                                       [ 98%]
test/registry/types/test_operator_registry.py::test_detect_invalid_jsonschema PASSED                                                                                                    [100%]

---------- coverage: platform darwin, python 2.7.16-final-0 ----------
Name                                             Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------
boundary_layer/__init__.py                          11      1      2      1    85%   25->26, 26
boundary_layer/builders/__init__.py                  3      0      0      0   100%
boundary_layer/builders/base.py                    108     11     40      8    87%   31, 35, 39, 102, 157->158, 158, 160->161, 161, 174->178, 175->174, 178, 182->183, 183, 187->193, 188->189, 189, 193, 234->238, 238
boundary_layer/builders/generator.py                11      0      0      0   100%
boundary_layer/builders/primary.py                  18      1      2      1    90%   34->37, 37
boundary_layer/builders/subdag.py                   11      0      0      0   100%
boundary_layer/builders/util.py                     63      2     30      2    96%   89->90, 90, 129->130, 130
boundary_layer/containers.py                         5      0      0      0   100%
boundary_layer/exceptions.py                        25      0      0      0   100%
boundary_layer/graph.py                            184      7     84      6    94%   112->113, 113, 117->118, 118, 123->124, 124, 344->345, 345, 392->393, 393, 480->481, 481-482
boundary_layer/logger.py                            12      0      0      0   100%
boundary_layer/oozier/__init__.py                    0      0      0      0   100%
boundary_layer/oozier/actions.py                    49      7      4      2    83%   39, 43, 47, 53, 57->58, 58, 92->93, 93, 101
boundary_layer/oozier/cluster_config.py             33      6      2      1    80%   9, 13, 17, 21, 30, 35, 56->59
boundary_layer/oozier/file_fetcher.py               42     22      2      0    45%   26, 65-75, 78-93, 99, 104-109
boundary_layer/oozier/jsp_macros.py                 33      2     18      2    92%   54->55, 55, 61->62, 62
boundary_layer/oozier/parse.py                     192     19     70     19    85%   56->60, 62->63, 63, 65->66, 66, 68->71, 71->72, 72, 84->85, 85, 91->92, 92-94, 130->131, 131, 164->165, 165, 188->191, 191->192, 192-203, 250->258, 258->259, 259, 273->274, 274, 313->314, 314, 325->328, 383->381, 389->390, 390, 393->exit
boundary_layer/oozier/schema.py                     71      2     13      2    95%   90->91, 91, 96->97, 97
boundary_layer/plugins/__init__.py                   4      0      0      0   100%
boundary_layer/plugins/base.py                      49      3      6      2    91%   47->49, 49, 64, 99->100, 100
boundary_layer/plugins/oozie_plugin.py              53      8     22      2    87%   69->70, 70, 72->73, 73, 95, 101, 107, 113, 116, 121
boundary_layer/plugins/plugin_manager.py           112     23     46      8    70%   40-51, 54->55, 55, 59->62, 62-74, 89->90, 90, 92->93, 93, 157, 163-164, 176->177, 177, 180->181, 181, 186->187, 187-191, 203->204, 204
boundary_layer/plugins/util.py                      12      1      4      1    88%   26->27, 27
boundary_layer/pretty_yaml.py                       44     35     14      0    16%   28-38, 58-96, 100, 108
boundary_layer/registry/__init__.py                  1      0      0      0   100%
boundary_layer/registry/registry.py                122     13     30      7    87%   39, 43, 49->50, 50, 84->85, 85, 135, 139, 142->143, 143, 146->147, 147-149, 157, 164->165, 165, 189->190, 190, 202->203, 203
boundary_layer/registry/types/__init__.py            5      0      0      0   100%
boundary_layer/registry/types/generator.py          12      0      0      0   100%
boundary_layer/registry/types/operator.py          170     10     68      7    92%   49->50, 50, 76->77, 77, 100->101, 101-102, 178->179, 179, 254->255, 255, 285->286, 286, 425->427, 427-430
boundary_layer/registry/types/preprocessor.py       36      4      8      2    86%   25, 29, 35->36, 36, 47->48, 48
boundary_layer/registry/types/resource.py           46      7     10      4    80%   24-27, 43->44, 44, 66->67, 67, 69->70, 70, 101->102, 102
boundary_layer/registry/types/subdag.py             10      0      0      0   100%
boundary_layer/schemas/__init__.py                   0      0      0      0   100%
boundary_layer/schemas/base.py                      11      2      6      1    71%   31->32, 32-33
boundary_layer/schemas/dag.py                      123     29     36     10    68%   46->49, 49-51, 125->127, 127-128, 134->137, 137-140, 146->149, 149-151, 157->159, 159-160, 166->167, 167, 168->169, 169-175, 199-200, 203->204, 204, 210->211, 211, 220->223, 223-228
boundary_layer/schemas/internal/__init__.py          0      0      0      0   100%
boundary_layer/schemas/internal/base.py             27      3      6      1    88%   37->40, 40, 57-58
boundary_layer/schemas/internal/generators.py        5      0      0      0   100%
boundary_layer/schemas/internal/operators.py        25      2     12      2    84%   48->49, 49, 66->67, 67
boundary_layer/schemas/internal/resources.py         8      0      0      0   100%
boundary_layer/schemas/internal/subdags.py           3      0      0      0   100%
boundary_layer/util.py                              59      6     22      3    89%   27-28, 31, 42->43, 43, 118->119, 119, 133->139, 139
boundary_layer/validator.py                         17      1      6      1    91%   32->34, 34
boundary_layer/workflow.py                         332     29    163     24    89%   46->47, 47, 49->50, 50, 69->72, 72, 114->115, 115, 129->130, 130, 137->138, 138, 141->142, 142, 158->159, 159, 217->218, 218, 250->251, 251, 275->276, 276-284, 292->293, 293-295, 325->326, 326, 350->351, 351, 378->379, 379, 381->382, 382, 512->513, 513, 532->533, 533, 709->715, 715->716, 716, 777->778, 778-779, 802->803, 803, 872->876, 876, 883->884, 884
boundary_layer_default_plugin/__init__.py            0      0      0      0   100%
boundary_layer_default_plugin/oozie_actions.py      66      2     10      4    92%   47, 113->114, 114, 117->127, 124->127, 138->143
boundary_layer_default_plugin/oozie_plugin.py       56     19     18      8    61%   31-36, 42-78, 93->94, 94, 114->117, 117->120, 122->125, 138->141, 141->144, 144->145, 145, 147->148, 148
boundary_layer_default_plugin/plugin.py             11      0      0      0   100%
boundary_layer_default_plugin/preprocessors.py     102     24     16      1    75%   37-38, 52-57, 68, 71-85, 94->95, 95, 110-122, 138-139
--------------------------------------------------------------------------------------------
TOTAL                                             2392    301    770    132    84%
Coverage XML written to file coverage.xml


================================================================================== 59 passed in 3.02 seconds ==================================================================================
py3 recreate: /Users/vchiapaikeo/development/boundary-layer/.tox/py3
py3 installdeps: pytest==3.8.1, pytest-cov==2.6.0, pytest-mock==1.10.0, pylint==1.9.3, pycodestyle==2.4.0, mock==2.0.0
py3 inst: /Users/vchiapaikeo/development/boundary-layer/.tox/.tmp/package/1/boundary-layer-1.7.10.dev0.zip
py3 installed: astroid==1.6.6,atomicwrites==1.3.0,attrs==19.3.0,boundary-layer==1.7.10.dev0,certifi==2020.4.5.1,cffi==1.14.0,chardet==3.0.4,coverage==5.1,cryptography==2.9.2,decorator==4.4.2,github3.py==1.3.0,idna==2.9,importlib-metadata==1.6.0,isort==4.3.21,Jinja2==2.11.2,jsonschema==2.6.0,jwcrypto==0.7,lazy-object-proxy==1.4.3,MarkupSafe==1.1.1,marshmallow==2.21.0,mccabe==0.6.1,mock==2.0.0,more-itertools==8.2.0,networkx==2.2,pbr==5.4.5,pluggy==0.13.1,py==1.8.1,pycodestyle==2.4.0,pycparser==2.20,pylint==1.9.3,pytest==3.8.1,pytest-cov==2.6.0,pytest-mock==1.10.0,python-dateutil==2.8.1,PyYAML==5.3.1,requests==2.23.0,semver==2.9.1,six==1.14.0,uritemplate==3.0.1,urllib3==1.25.9,wrapt==1.12.1,xmltodict==0.12.0,zipp==3.1.0
py3 run-test-pre: PYTHONHASHSEED='2450988460'
py3 run-test: commands[0] | pytest -vv test
===================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.7.4, pytest-3.8.1, py-1.8.1, pluggy-0.13.1 -- /Users/vchiapaikeo/development/boundary-layer/.tox/py3/bin/python
cachedir: .pytest_cache
rootdir: /Users/vchiapaikeo/development/boundary-layer, inifile:
plugins: mock-1.10.0, cov-2.6.0
collected 59 items                                                                                                                                                                            

test/test_generators.py::test_default_param_filler PASSED                                                                                                                               [  1%]
test/test_graph.py::test_node_comparison PASSED                                                                                                                                         [  3%]
test/test_graph.py::test_graph_builder PASSED                                                                                                                                           [  5%]
test/test_graph.py::test_invalid_upstream_ref PASSED                                                                                                                                    [  6%]
test/test_graph.py::test_invalid_downstream_ref PASSED                                                                                                                                  [  8%]
test/test_graph.py::test_cycle_detector PASSED                                                                                                                                          [ 10%]
test/test_graph.py::test_boundary_extractor PASSED                                                                                                                                      [ 11%]
test/test_graph.py::test_orderer PASSED                                                                                                                                                 [ 13%]
test/test_graph.py::test_dependency_set_computations PASSED                                                                                                                             [ 15%]
test/test_graph.py::test_flow_control_inserter_auto_fc_node PASSED                                                                                                                      [ 16%]
test/test_graph.py::test_flow_control_inserter PASSED                                                                                                                                   [ 18%]
test/test_graph.py::test_flow_control_inserter_invalid_args PASSED                                                                                                                      [ 20%]
test/test_graph.py::test_resource_boundaries PASSED                                                                                                                                     [ 22%]
test/test_graph.py::test_bundler_inserter PASSED                                                                                                                                        [ 23%]
test/test_graph.py::test_default_bundler_inserter PASSED                                                                                                                                [ 25%]
test/test_graph.py::test_attach_create_resource PASSED                                                                                                                                  [ 27%]
test/test_graph.py::test_attach_destroy_resource PASSED                                                                                                                                 [ 28%]
test/test_graph.py::test_attach_destroy_resource_no_sentinel_by_config PASSED                                                                                                           [ 30%]
test/test_graph.py::test_attach_destroy_resource_no_sentinel_because_other_leaf_nodes PASSED                                                                                            [ 32%]
test/test_graph.py::test_prune_node PASSED                                                                                                                                              [ 33%]
test/test_graph.py::test_prune_nodes PASSED                                                                                                                                             [ 35%]
test/test_workflow.py::test_parse_workflow_with_resources PASSED                                                                                                                        [ 37%]
test/test_workflow.py::test_parse_workflow_with_subdag PASSED                                                                                                                           [ 38%]
test/test_workflow.py::test_parse_workflow_with_generator PASSED                                                                                                                        [ 40%]
test/test_workflow.py::test_parse_workflow_with_multiple_generators PASSED                                                                                                              [ 42%]
test/test_workflow.py::test_parse_invalid_workflows PASSED                                                                                                                              [ 44%]
test/test_workflow.py::test_build_referrer_map PASSED                                                                                                                                   [ 45%]
test/test_workflow.py::test_node_path_builder PASSED                                                                                                                                    [ 47%]
test/test_workflow.py::test_invalid_node_reference_errors PASSED                                                                                                                        [ 49%]
test/test_workflow.py::test_node_path_partitioner PASSED                                                                                                                                [ 50%]
test/test_workflow.py::test_workflow_prune PASSED                                                                                                                                       [ 52%]
test/test_workflow.py::test_workflow_prune_only_nodes PASSED                                                                                                                            [ 54%]
test/test_workflow.py::test_workflow_prune_resulting_in_unreachable PASSED                                                                                                              [ 55%]
test/test_workflow.py::test_only_subdag_operator_includes_sub_workflow PASSED                                                                                                           [ 57%]
test/builders/test_util.py::test_sanitize_operator_name PASSED                                                                                                                          [ 59%]
test/builders/test_util.py::test_verbatim PASSED                                                                                                                                        [ 61%]
test/builders/test_util.py::test_construct_dag_name PASSED                                                                                                                              [ 62%]
test/builders/test_util.py::test_subdag_builder_name PASSED                                                                                                                             [ 64%]
test/builders/test_util.py::test_add_leading_spaces PASSED                                                                                                                              [ 66%]
test/builders/test_util.py::test_enquote PASSED                                                                                                                                         [ 67%]
test/builders/test_util.py::test_split_verbatim PASSED                                                                                                                                  [ 69%]
test/builders/test_util.py::test_format_value PASSED                                                                                                                                    [ 71%]
test/builders/test_util.py::test_comment PASSED                                                                                                                                         [ 72%]
test/default_plugin/test_plugin.py::test_valid_plugin PASSED                                                                                                                            [ 74%]
test/default_plugin/test_preprocessors.py::test_ensure_rendered_string_pattern PASSED                                                                                                   [ 76%]
test/oozier/test_jsp_translator.py::test_macro_translator PASSED                                                                                                                        [ 77%]
test/oozier/test_jsp_translator.py::test_macro_translator_unknown_macro PASSED                                                                                                          [ 79%]
test/oozier/test_jsp_translator.py::test_macro_translator_unknown_input_type PASSED                                                                                                     [ 81%]
test/oozier/test_oozie_converter.py::test_workflow_parser PASSED                                                                                                                        [ 83%]
test/oozier/test_oozie_converter.py::test_workflow_parser_with_prune_forks PASSED                                                                                                       [ 84%]
test/plugins/test_plugin_manager.py::test_plugin_manager_default PASSED                                                                                                                 [ 86%]
test/plugins/test_plugin_manager.py::test_plugin_manager_multiple_priorities PASSED                                                                                                     [ 88%]
test/plugins/test_plugin_manager.py::test_plugin_manager_duplicate_priorities PASSED                                                                                                    [ 89%]
test/registry/types/test_operator_registry.py::test_operator_registry PASSED                                                                                                            [ 91%]
test/registry/types/test_operator_registry.py::test_reject_unknown_properties PASSED                                                                                                    [ 93%]
test/registry/types/test_operator_registry.py::test_accept_unknown_properties_for_flexible_schema PASSED                                                                                [ 94%]
test/registry/types/test_operator_registry.py::test_fail_on_missing_preprocessor PASSED                                                                                                 [ 96%]
test/registry/types/test_operator_registry.py::test_detect_duplicate_names PASSED                                                                                                       [ 98%]
test/registry/types/test_operator_registry.py::test_detect_invalid_jsonschema PASSED                                                                                                    [100%]

====================================================================================== warnings summary =======================================================================================
/Users/vchiapaikeo/development/boundary-layer/.tox/py3/lib/python3.7/site-packages/networkx/classes/graph.py:23: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import Mapping

/Users/vchiapaikeo/development/boundary-layer/.tox/py3/lib/python3.7/site-packages/networkx/classes/reportviews.py:95: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import Mapping, Set, Iterable
/Users/vchiapaikeo/development/boundary-layer/.tox/py3/lib/python3.7/site-packages/networkx/classes/reportviews.py:95: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import Mapping, Set, Iterable

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================================================ 59 passed, 3 warnings in 1.34 seconds ============================================================================
lint recreate: /Users/vchiapaikeo/development/boundary-layer/.tox/lint
lint installdeps: pytest==3.8.1, pytest-cov==2.6.0, pytest-mock==1.10.0, pylint==1.9.3, pycodestyle==2.4.0, mock==2.0.0
lint inst: /Users/vchiapaikeo/development/boundary-layer/.tox/.tmp/package/1/boundary-layer-1.7.10.dev0.zip
lint installed: DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support,astroid==1.6.6,atomicwrites==1.3.0,attrs==19.3.0,backports.functools-lru-cache==1.6.1,boundary-layer==1.7.10.dev0,certifi==2020.4.5.1,cffi==1.14.0,chardet==3.0.4,configparser==4.0.2,contextlib2==0.6.0.post1,coverage==5.1,cryptography==2.9.2,decorator==4.4.2,enum34==1.1.10,funcsigs==1.0.2,functools32==3.2.3.post2,futures==3.3.0,github3.py==1.3.0,idna==2.9,importlib-metadata==1.6.0,ipaddress==1.0.23,isort==4.3.21,Jinja2==2.11.2,jsonschema==2.6.0,jwcrypto==0.7,lazy-object-proxy==1.4.3,MarkupSafe==1.1.1,marshmallow==2.21.0,mccabe==0.6.1,mock==2.0.0,more-itertools==5.0.0,networkx==2.2,pathlib2==2.3.5,pbr==5.4.5,pluggy==0.13.1,py==1.8.1,pycodestyle==2.4.0,pycparser==2.20,pylint==1.9.3,pytest==3.8.1,pytest-cov==2.6.0,pytest-mock==1.10.0,python-dateutil==2.8.1,PyYAML==5.3.1,requests==2.23.0,scandir==1.10.0,semver==2.9.1,singledispatch==3.4.0.3,six==1.14.0,uritemplate==3.0.1,urllib3==1.25.9,wrapt==1.12.1,xmltodict==0.12.0,zipp==1.2.0
lint run-test-pre: PYTHONHASHSEED='2450988460'
lint run-test: commands[0] | pycodestyle boundary_layer boundary_layer_default_plugin bin/boundary-layer test
lint run-test: commands[1] | pylint --rcfile=.pylintrc boundary_layer boundary_layer_default_plugin bin/boundary-layer
Using config file /Users/vchiapaikeo/development/boundary-layer/.pylintrc

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

lint run-test: commands[2] | pylint --rcfile=.pylintrc.test test
Using config file /Users/vchiapaikeo/development/boundary-layer/.pylintrc.test

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________ summary ________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________
  py27: commands succeeded
  py3: commands succeeded
  lint: commands succeeded
  congratulations :)
```