### PR TITLE
Adding support for GKEPodOperator

### DIFF
--- a/boundary_layer_default_plugin/config/operators/gke_pod_operator.yaml
+++ b/boundary_layer_default_plugin/config/operators/gke_pod_operator.yaml
@@ -17,90 +17,91 @@
 name: gke_pod_operator
 operator_class: GKEPodOperator
 operator_class_module: airflow.contrib.operators.gcp_container_operator 
-parameters_jsonschema: base
-    properties:
-        location:
-          type:  str
-        project_id: 
-          type: str
-        cluster_name:
-          type: str
-        name:
+schema_extends: base
+parameters_jsonschema:
+  properties:
+    location: 
+      type: string
+    project_id: 
+      type: string
+    cluster_name:
+      type: string
+    name:
+      type: string
+    namespace:
+      type: string
+    gcp_conn_id: 
+      type: string
+    image:
+      type: string
+    cmds:
+      type: array
+      items:
           type: string
-        namespace:
+    arguments:
+      type: array
+      items:
           type: string
-        gcp_conn_id: 
-          type: str
-        image:
-          type: string
-        cmds:
-          type: array
-          items:
-            type: string
-        arguments:
-          type: array
-          items:
-            type: string
-        image_pull_policy:
-          type: string
-        image_pull_secrets:
-          type: string
-        labels:
+    image_pull_policy:
+      type: string
+    image_pull_secrets:
+      type: string
+    labels:
+      type: object
+    startup_timeout_seconds:
+      type: integer
+    env_vars:
+      type: object
+    in_cluster:
+      type: boolean
+    cluster_context:
+      type: string
+    get_logs:
+      type: boolean
+    annotations:
+      type: object
+    resources:
+      type: object
+    affinity:
+      type: object
+    node_selectors:
+      type: object
+    config_file:
+      type: string
+    xcom_push:
+      type: boolean
+    is_delete_operator_pod:
+      type: boolean
+    hostnetwork:
+      type: boolean
+    configmaps:
+      type: array
+      items:
+        type: string
+    dns_policy:
+      type: string
+    volumes:
+      type: array
+    items:
+      type: object
+    volume_mounts:
+      type: array
+      items:
+        type: object
+    secrets:
+      type: array
+      items:
+        type: object
+    tolerations:
+        type: array
+        items:
           type: object
-        startup_timeout_seconds:
-          type: integer
-        env_vars:
-          type: object
-        in_cluster:
-          type: boolean
-        cluster_context:
-          type: string
-        get_logs:
-          type: boolean
-        annotations:
-          type: object
-        resources:
-          type: object
-        affinity:
-          type: object
-        node_selectors:
-          type: object
-        config_file:
-          type: string
-        xcom_push:
-          type: boolean
-        is_delete_operator_pod:
-          type: boolean
-        hostnetwork:
-          type: boolean
-        configmaps:
-          type: array
-          items:
-            type: string
-        dns_policy:
-          type: string
-        volumes:
-          type: array
-          items:
-            type: object
-        volume_mounts:
-          type: array
-          items:
-            type: object
-        secrets:
-          type: array
-          items:
-            type: object
-        tolerations:
-           type: array
-           items:
-             type: object
-      additionalProperties: false
-      required:
-      - task_id
-      - project_id
-      - location
-      - cluster_name
-      - name
-      - namespace
-      - image
+  additionalProperties: false
+  required:
+    - task_id
+    - project_id
+    - location
+    - cluster_name
+    - name
+    - namespace
+    - image

--- a/boundary_layer_default_plugin/config/operators/gke_pod_operator.yaml
+++ b/boundary_layer_default_plugin/config/operators/gke_pod_operator.yaml
@@ -17,21 +17,23 @@
 name: gke_pod_operator
 operator_class: GKEPodOperator
 operator_class_module: airflow.contrib.operators.gcp_container_operator 
-schema_extends: kubenetes
-parameters_jsonschema:
-  properties:
-    task_id: 
-      type: string
-    project_id: 
-      type: string
-    cluster_name:
-      type: string
-  additionalProperties: false
-  required:
-    - task_id
-    - project_id
-    - location
-    - cluster_name
-    - name
-    - namespace
-    - image
+schema_extends: kubernetes
+parameters_jsonschema: base
+    properties:
+        task_id
+          type:  str
+        project_id: 
+          type: str
+        location
+          type: str
+        cluster_name:
+          type: str
+      additionalProperties: false
+      required:
+      - task_id
+      - project_id
+      - location
+      - cluster_name
+      - name
+      - namespace
+      - image

--- a/boundary_layer_default_plugin/config/operators/gke_pod_operator.yaml
+++ b/boundary_layer_default_plugin/config/operators/gke_pod_operator.yaml
@@ -1,0 +1,106 @@
+# Copyright 2020 Etsy Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+# see: https://github.com/apache/airflow/blob/1.10.3/airflow/contrib/operators/gcp_container_operator.py
+
+name: gke_pod_operator
+operator_class: GKEPodOperator
+operator_class_module: airflow.contrib.operators.gcp_container_operator 
+parameters_jsonschema: base
+    properties:
+        location:
+          type:  str
+        project_id: 
+          type: str
+        cluster_name:
+          type: str
+        name:
+          type: string
+        namespace:
+          type: string
+        gcp_conn_id: 
+          type: str
+        image:
+          type: string
+        cmds:
+          type: array
+          items:
+            type: string
+        arguments:
+          type: array
+          items:
+            type: string
+        image_pull_policy:
+          type: string
+        image_pull_secrets:
+          type: string
+        labels:
+          type: object
+        startup_timeout_seconds:
+          type: integer
+        env_vars:
+          type: object
+        in_cluster:
+          type: boolean
+        cluster_context:
+          type: string
+        get_logs:
+          type: boolean
+        annotations:
+          type: object
+        resources:
+          type: object
+        affinity:
+          type: object
+        node_selectors:
+          type: object
+        config_file:
+          type: string
+        xcom_push:
+          type: boolean
+        is_delete_operator_pod:
+          type: boolean
+        hostnetwork:
+          type: boolean
+        configmaps:
+          type: array
+          items:
+            type: string
+        dns_policy:
+          type: string
+        volumes:
+          type: array
+          items:
+            type: object
+        volume_mounts:
+          type: array
+          items:
+            type: object
+        secrets:
+          type: array
+          items:
+            type: object
+        tolerations:
+           type: array
+           items:
+             type: object
+      additionalProperties: false
+      required:
+      - task_id
+      - project_id
+      - location
+      - cluster_name
+      - name
+      - namespace
+      - image

--- a/boundary_layer_default_plugin/config/operators/gke_pod_operator.yaml
+++ b/boundary_layer_default_plugin/config/operators/gke_pod_operator.yaml
@@ -17,85 +17,15 @@
 name: gke_pod_operator
 operator_class: GKEPodOperator
 operator_class_module: airflow.contrib.operators.gcp_container_operator 
-schema_extends: base
+schema_extends: kubenetes
 parameters_jsonschema:
   properties:
-    location: 
+    task_id: 
       type: string
     project_id: 
       type: string
     cluster_name:
       type: string
-    name:
-      type: string
-    namespace:
-      type: string
-    gcp_conn_id: 
-      type: string
-    image:
-      type: string
-    cmds:
-      type: array
-      items:
-          type: string
-    arguments:
-      type: array
-      items:
-          type: string
-    image_pull_policy:
-      type: string
-    image_pull_secrets:
-      type: string
-    labels:
-      type: object
-    startup_timeout_seconds:
-      type: integer
-    env_vars:
-      type: object
-    in_cluster:
-      type: boolean
-    cluster_context:
-      type: string
-    get_logs:
-      type: boolean
-    annotations:
-      type: object
-    resources:
-      type: object
-    affinity:
-      type: object
-    node_selectors:
-      type: object
-    config_file:
-      type: string
-    xcom_push:
-      type: boolean
-    is_delete_operator_pod:
-      type: boolean
-    hostnetwork:
-      type: boolean
-    configmaps:
-      type: array
-      items:
-        type: string
-    dns_policy:
-      type: string
-    volumes:
-      type: array
-    items:
-      type: object
-    volume_mounts:
-      type: array
-      items:
-        type: object
-    secrets:
-      type: array
-      items:
-        type: object
-    tolerations:
-        type: array
-        items:
-          type: object
   additionalProperties: false
   required:
     - task_id

--- a/boundary_layer_default_plugin/config/operators/kubernetes.yaml
+++ b/boundary_layer_default_plugin/config/operators/kubernetes.yaml
@@ -16,77 +16,13 @@
 name: kubernetes
 operator_class: KubernetesPodOperator
 operator_class_module: airflow.contrib.operators.kubernetes_pod_operator 
-schema_extends: base
+schema_extends: kubernetes
 parameters_jsonschema:
     properties:
-        image:
-          type: string
-        namespace:
-          type: string
-        cmds:
-          type: array
-          items:
-            type: string
-        arguments:
-          type: array
-          items:
-            type: string
-        image_pull_policy:
-          type: string
-        image_pull_secrets:
-          type: string
-        labels:
-          type: object
-        startup_timeout_seconds:
-          type: integer
-        name:
-          type: string
-        env_vars:
-          type: object
-        in_cluster:
-          type: boolean
-        cluster_context:
-          type: string
-        get_logs:
-          type: boolean
-        annotations:
-          type: object
-        resources:
-          type: object
-        affinity:
-          type: object
-        node_selectors:
-          type: object
-        config_file:
-          type: string
         xcom_push:
           type: boolean
-        is_delete_operator_pod:
-          type: boolean
-        hostnetwork:
-          type: boolean
-        configmaps:
-          type: array
-          items:
-            type: string
         dns_policy:
           type: string
-        volumes:
-          type: array
-          items:
-            type: object
-        volume_mounts:
-          type: array
-          items:
-            type: object
-        secrets:
-          type: array
-          items:
-            type: object
-        tolerations:
-           type: array
-           items:
-             type: object
     additionalProperties: false
     required:
       - image

--- a/boundary_layer_default_plugin/config/operators/kubernetes.yaml
+++ b/boundary_layer_default_plugin/config/operators/kubernetes.yaml
@@ -16,13 +16,77 @@
 name: kubernetes
 operator_class: KubernetesPodOperator
 operator_class_module: airflow.contrib.operators.kubernetes_pod_operator 
-schema_extends: kubernetes
+schema_extends: base
 parameters_jsonschema:
     properties:
+        image:
+          type: string
+        namespace:
+          type: string
+        cmds:
+          type: array
+          items:
+            type: string
+        arguments:
+          type: array
+          items:
+            type: string
+        image_pull_policy:
+          type: string
+        image_pull_secrets:
+          type: string
+        labels:
+          type: object
+        startup_timeout_seconds:
+          type: integer
+        name:
+          type: string
+        env_vars:
+          type: object
+        in_cluster:
+          type: boolean
+        cluster_context:
+          type: string
+        get_logs:
+          type: boolean
+        annotations:
+          type: object
+        resources:
+          type: object
+        affinity:
+          type: object
+        node_selectors:
+          type: object
+        config_file:
+          type: string
         xcom_push:
           type: boolean
+        is_delete_operator_pod:
+          type: boolean
+        hostnetwork:
+          type: boolean
+        configmaps:
+          type: array
+          items:
+            type: string
         dns_policy:
           type: string
+        volumes:
+          type: array
+          items:
+            type: object
+        volume_mounts:
+          type: array
+          items:
+            type: object
+        secrets:
+          type: array
+          items:
+            type: object
+        tolerations:
+           type: array
+           items:
+             type: object
     additionalProperties: false
     required:
       - image


### PR DESCRIPTION
Sometimes the KubernetesPodOperator cannot be used because of the way the user tokens are used. The GKEPodOperator extends the KubernetesPodOperator by requiring fields needed to pull the proper configurations via `kubectl`. This removes the need for Airflow to know the kube_config before run-time. And given that kube_config can be VERY dynamic this is a better implementation for some use cases. 
