### PR TITLE
Add master_type parameter to ml_engine_training operator

### DIFF
--- a/boundary_layer_default_plugin/config/operators/ml_engine_training.yaml
+++ b/boundary_layer_default_plugin/config/operators/ml_engine_training.yaml
@@ -38,6 +38,8 @@ parameters_jsonschema:
         scale_tier:
             type: string
             enum: [BASIC, STANDARD_1, PREMIUM_1, BASIC_GPU, BASIC_TPU, CUSTOM]
+        master_type:
+            type: string
         runtime_version:
             type: string
         python_version:


### PR DESCRIPTION
Airflow versions prior to 1.10.4 are missing a master_type parameter to the MLEngineTrainingOperator. This is resolved going forward but is also handled in patch [AIRFLOW-3624](https://issues.apache.org/jira/browse/AIRFLOW-3624) that we recently applied to our Airflow. 

The latest stable version of Airflow has this parameter (along with all Airflows released after 1.10.4). https://airflow.apache.org/docs/stable/_api/airflow/contrib/operators/mlengine_operator/index.html#airflow.contrib.operators.mlengine_operator.MLEngineTrainingOperator