### PR TITLE
Migrate to Marshmallow 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ coverage.xml
 .tox
 .*.sw[op]
 .idea/
+.eggs
+build

--- a/boundary_layer/oozier/actions.py
+++ b/boundary_layer/oozier/actions.py
@@ -53,11 +53,9 @@ class OozieActionBuilderWithSchema(OozieActionBuilder):
         pass
 
     def __init__(self, context, action_metadata, data):
-        loaded = self.schema(context=context).load(data)
-        if loaded.errors:
-            raise ma.ValidationError(loaded.errors)
+        loaded_data = self.schema(context=context).load(data)
 
-        super(OozieActionBuilderWithSchema, self).__init__(context, action_metadata, loaded.data)
+        super(OozieActionBuilderWithSchema, self).__init__(context, action_metadata, loaded_data)
 
     def get_action(self):
         result = self.action_metadata.copy()
@@ -67,7 +65,7 @@ class OozieActionBuilderWithSchema(OozieActionBuilder):
 
 
 class OozieSubWorkflowActionSchema(OozieBaseSchema):
-    app_path = ma.fields.String(required=True, load_from='app-path')
+    app_path = ma.fields.String(required=True, data_key='app-path')
     propagate_configuration = ma.fields.Dict(allow_none=True)
 
 

--- a/boundary_layer/oozier/schema.py
+++ b/boundary_layer/oozier/schema.py
@@ -20,7 +20,7 @@ class OozieBaseSchema(ma.Schema):
     singletons_to_lists = []
 
     @ma.pre_load
-    def _convert_singletons_to_lists(self, data):
+    def _convert_singletons_to_lists(self, data, **kwargs):
         if all(isinstance(data.get(key, []), list) for key in self.singletons_to_lists):
             return data
 
@@ -34,15 +34,15 @@ class OozieBaseSchema(ma.Schema):
 
 
 class OozieNamedObjectSchema(OozieBaseSchema):
-    name = ma.fields.String(required=True, load_from='@name')
+    name = ma.fields.String(required=True, data_key='@name')
 
 
 class OozieFlowControlSchema(OozieBaseSchema):
-    to = ma.fields.String(required=True, load_from='@to')
+    to = ma.fields.String(required=True, data_key='@to')
 
 
 class OozieForkStartSchema(OozieBaseSchema):
-    start = ma.fields.String(required=True, load_from='@start')
+    start = ma.fields.String(required=True, data_key='@start')
 
 
 class OozieForkSchema(OozieNamedObjectSchema):
@@ -51,7 +51,7 @@ class OozieForkSchema(OozieNamedObjectSchema):
     singletons_to_lists = ['path']
 
     @ma.post_load
-    def add_base_operator(self, data):
+    def add_base_operator(self, data, **kwargs):
         operator = {
             'name': data['name'],
             'type': 'flow_control',
@@ -64,7 +64,7 @@ class OozieForkSchema(OozieNamedObjectSchema):
 
 class OozieJoinSchema(OozieNamedObjectSchema, OozieFlowControlSchema):
     @ma.post_load
-    def add_base_operator(self, data):
+    def add_base_operator(self, data, **kwargs):
         operator = {
             'name': data['name'],
             'type': 'flow_control',
@@ -101,7 +101,7 @@ class OozieActionSchema(OozieNamedObjectSchema):
         return keyed_action_builders[keys_present[0]]
 
     @ma.validates_schema(pass_original=True)
-    def one_action_type(self, _, original):
+    def one_action_type(self, _, original, **kwargs):
         """ Runs the validation checks to make sure that exactly one
             known action is present, and prints an error message based on
             the content of the original, unparsed input
@@ -109,7 +109,7 @@ class OozieActionSchema(OozieNamedObjectSchema):
         self._get_action_builder(original)
 
     @ma.post_load(pass_original=True)
-    def fetch_base_action(self, data, original):
+    def fetch_base_action(self, data, original, **kwargs):
         builder_cls = self._get_action_builder(original)
 
         return builder_cls(self.context, data, original[builder_cls.key])
@@ -120,7 +120,7 @@ class OozieKillSchema(OozieNamedObjectSchema):
 
 
 class OozieCaseSchema(OozieFlowControlSchema):
-    text = ma.fields.String(required=True, load_from='#text')
+    text = ma.fields.String(required=True, data_key='#text')
 
 
 class OozieSwitchSchema(OozieBaseSchema):
@@ -135,7 +135,7 @@ class OozieDecisionSchema(OozieNamedObjectSchema):
 
 
 class OozieWorkflowAppSchema(OozieNamedObjectSchema):
-    name = ma.fields.String(required=True, load_from='@name')
+    name = ma.fields.String(required=True, data_key='@name')
     action = ma.fields.List(ma.fields.Nested(OozieActionSchema), missing=[])
     join = ma.fields.List(ma.fields.Nested(OozieJoinSchema), missing=[])
     fork = ma.fields.List(ma.fields.Nested(OozieForkSchema), missing=[])
@@ -150,8 +150,8 @@ class OozieWorkflowAppSchema(OozieNamedObjectSchema):
 
 class OozieWorkflowSchema(OozieBaseSchema):
     workflow_app = ma.fields.Nested(
-        OozieWorkflowAppSchema, load_from='workflow-app', required=True)
+        OozieWorkflowAppSchema, data_key='workflow-app', required=True)
 
     @ma.post_load
-    def return_workflow(self, data):
+    def return_workflow(self, data, **kwargs):
         return data['workflow_app']

--- a/boundary_layer/plugins/plugin_manager.py
+++ b/boundary_layer/plugins/plugin_manager.py
@@ -64,14 +64,15 @@ class PluginManager(object):
                 'Config schema for plugin {} is not a marshmallow Schema. '
                 'Found: {}'.format(plugin.name, plugin.config_schema_cls))
 
-        parsed_config = plugin.config_schema_cls().load(config or {})
-        if parsed_config.errors:
+        try:
+            parsed_config_data = plugin.config_schema_cls().load(config or {})
+        except ValidationError as err:
             raise Exception(
                 'Errors parsing configuration for plugin {}: {}'.format(
                     plugin.name,
-                    parsed_config.errors))
+                    err.messages))
 
-        return parsed_config.data
+        return parsed_config_data
 
     def insert_imports(self, plugin_config):
         objects = []

--- a/boundary_layer/registry/registry.py
+++ b/boundary_layer/registry/registry.py
@@ -17,6 +17,7 @@ import abc
 import os
 from enum import Enum
 import yaml
+from marshmallow import ValidationError
 
 from boundary_layer.logger import logger
 from boundary_layer import util
@@ -177,13 +178,13 @@ class ConfigFileRegistry(Registry):
 
         logger.debug('validating item %s against schema %s',
                      item, self.spec_schema_cls.__name__)
-
-        loaded = self.spec_schema_cls().load(item)
-        if loaded.errors:
+        try:
+            data = self.spec_schema_cls().load(item)
+        except ValidationError as err:
             raise InvalidConfig('Invalid config spec in file {}: {}'.format(
-                filename, loaded.errors))
+                filename, err.messages))
 
-        return loaded.data
+        return data
 
     def load_configs(self, config_paths):
         if not isinstance(config_paths, list):

--- a/boundary_layer/registry/types/operator.py
+++ b/boundary_layer/registry/types/operator.py
@@ -14,6 +14,7 @@
 #     limitations under the License.
 
 import six
+from marshmallow import ValidationError
 from boundary_layer.logger import logger
 from boundary_layer.registry import ConfigFileRegistry, RegistryNode, NodeTypes
 from boundary_layer.schemas.internal.operators import OperatorSpecSchema
@@ -79,15 +80,14 @@ class OperatorNode(RegistryNode):
                 'resolve_properties() has not been called yet!'.format(
                     self))
 
-        loaded = ImportSchema().load(self.config.get('imports', {}))
-
-        assert not loaded.errors, \
-            ('Internal error: processing `imports` config {} for '
-             'operator `{}`').format(
+        try:
+            result = ImportSchema().load(self.config.get('imports', {}))
+        except ValidationError as err:
+            raise Exception(
+                ('Internal error: processing `imports` config {} for '
+                'operator `{}`').format(
                  self.config.get('imports', {}),
-                 self.name)
-
-        result = loaded.data
+                 self.name))
 
         if self.operator_class:
             result.setdefault('objects', [])

--- a/boundary_layer/registry/types/preprocessor.py
+++ b/boundary_layer/registry/types/preprocessor.py
@@ -14,6 +14,7 @@
 #     limitations under the License.
 
 import abc
+from marshmallow import ValidationError
 from boundary_layer.registry import Registry, RegistryNode, NodeTypes
 
 
@@ -43,14 +44,15 @@ class PropertyPreprocessor(object):
             self.properties = None
             return
 
-        loaded = self.properties_schema_cls().load(properties)
-        if loaded.errors:
+        try:
+            data = self.properties_schema_cls().load(properties)
+        except ValidationError as err:
             raise Exception(
-                'Error parsing properties for preprocessor `{}`: {}'.format(
+                'Error parsing properties for preprocessor {}: {}'.format(
                     self.type,
-                    loaded.errors))
+                    err.messages))
 
-        self.properties = loaded.data
+        self.properties = data
 
     @property
     def properties_schema_cls(self):

--- a/boundary_layer/schemas/base.py
+++ b/boundary_layer/schemas/base.py
@@ -22,7 +22,7 @@ import marshmallow as ma
 
 class StrictSchema(ma.Schema):
     @ma.validates_schema(pass_original=True)
-    def check_no_unknowns(self, _, original_data):
+    def check_no_unknowns(self, _, original_data, **kwargs):
         def check_single_datum(datum):
             unknown = set(datum) - set(self.fields)
             if unknown:

--- a/boundary_layer/schemas/dag.py
+++ b/boundary_layer/schemas/dag.py
@@ -42,7 +42,7 @@ class GeneratorSchema(ReferenceSchema):
     regex_blocklist = fields.List(fields.String())
 
     @validates_schema
-    def check_task_id_mode(self, data):
+    def check_task_id_mode(self, data, **kwargs):
         if 'auto_task_id_mode' not in data:
             return
 
@@ -118,7 +118,7 @@ class DagArgsSchema(StrictSchema):
     access_control = fields.Dict()
 
     @validates_schema
-    def validate_callbacks(self, data):
+    def validate_callbacks(self, data, **kwargs):
         callbacks = ['sla_miss_callback', 'on_success_callback',
                      'on_failure_callback']
         for cb in callbacks:
@@ -130,7 +130,7 @@ class DagArgsSchema(StrictSchema):
                     [cb])
 
     @validates_schema
-    def validate_default_view(self, data):
+    def validate_default_view(self, data, **kwargs):
         if 'default_view' not in data:
             return
 
@@ -142,7 +142,7 @@ class DagArgsSchema(StrictSchema):
                 ['default_view'])
 
     @validates_schema
-    def validate_orientation(self, data):
+    def validate_orientation(self, data, **kwargs):
         if 'orientation' not in data:
             return
 
@@ -153,7 +153,7 @@ class DagArgsSchema(StrictSchema):
                 ['orientation'])
 
     @validates_schema
-    def validate_template_undefined(self, data):
+    def validate_template_undefined(self, data, **kwargs):
         if 'template_undefined' not in data:
             return
         if not re.compile('<<.+>>').match(data['template_undefined']):
@@ -162,7 +162,7 @@ class DagArgsSchema(StrictSchema):
                 ['template_undefined'])
 
     @post_dump
-    def dagrun_timeout_to_timedelta(self, data):
+    def dagrun_timeout_to_timedelta(self, data, **kwargs):
         if not self.context.get('for_dag_output'):
             return data
         if 'dagrun_timeout' in data:
@@ -189,7 +189,7 @@ class PrimaryDagSchema(BaseDagSchema):
     plugin_config = fields.Dict()
 
     @validates_schema
-    def validate_compatibility_version(self, data):
+    def validate_compatibility_version(self, data, **kwargs):
         if not data.get('compatibility_version'):
             return
 
@@ -215,7 +215,7 @@ class PrimaryDagSchema(BaseDagSchema):
                 ['compatibility_version'])
 
     @validates_schema
-    def validate_plugin_config(self, data):
+    def validate_plugin_config(self, data, **kwargs):
         from boundary_layer import plugins
         if 'plugin_config' not in data:
             return

--- a/boundary_layer/schemas/internal/base.py
+++ b/boundary_layer/schemas/internal/base.py
@@ -33,7 +33,7 @@ class BaseSpecSchema(StrictSchema):
     schema_extends = ma.fields.String()
 
     @ma.validates_schema
-    def jsonschema_or_extended(self, data):
+    def jsonschema_or_extended(self, data, **kwargs):
         if 'parameters_jsonschema' in data or 'schema_extends' in data:
             return
 
@@ -43,7 +43,7 @@ class BaseSpecSchema(StrictSchema):
                 data.get('name', data)))
 
     @ma.validates_schema
-    def check_jsonschema(self, data):
+    def check_jsonschema(self, data, **kwargs):
         if 'parameters_jsonschema' not in data:
             return
         # Make sure that `properties` is present, because it's not actually

--- a/boundary_layer/schemas/internal/operators.py
+++ b/boundary_layer/schemas/internal/operators.py
@@ -32,7 +32,7 @@ class OperatorSpecSchema(BaseSpecSchema):
     property_preprocessors = ma.fields.List(ma.fields.Nested(PropertyPreprocessorSchema))
 
     @ma.validates_schema
-    def valid_preprocessor_property_names(self, data):
+    def valid_preprocessor_property_names(self, data, **kwargs):
         preprocessors = data.get('property_preprocessors', [])
 
         if not preprocessors:

--- a/boundary_layer/workflow.py
+++ b/boundary_layer/workflow.py
@@ -15,6 +15,7 @@
 
 import os
 from collections import namedtuple, Counter
+from marshmallow import ValidationError
 
 import six
 import yaml
@@ -288,14 +289,13 @@ class Workflow(object):
         """ Parse the DAG using the specified schema class.  Raise an exception
             if any errors are detected.
         """
-        loaded = schema_cls().load(dag)
-        if loaded.errors:
+        try:
+            parsed = schema_cls().load(dag)
+        except ValidationError as err:
             dag_description = 'primary' if issubclass(
                 schema_cls, PrimaryDagSchema) else 'sub'
             raise Exception('Found errors in {} dag: {}'.format(
-                dag_description, loaded.errors))
-
-        parsed = loaded.data
+                dag_description, err.messages))
 
         registries = {
             'resources': plugins.manager.resources,

--- a/boundary_layer_default_plugin/oozie_actions.py
+++ b/boundary_layer_default_plugin/oozie_actions.py
@@ -28,7 +28,7 @@ class OozieFileSystemSourceDestSchema(OozieBaseSchema):
 
 
 class OozieFileSystemPathSchema(OozieBaseSchema):
-    path = ma.fields.String(required=True, load_from='@path')
+    path = ma.fields.String(required=True, data_key='@path')
 
 
 class OozieFileSystemActionSchema(OozieBaseSchema):
@@ -83,7 +83,7 @@ class OozieHadoopConfigurationSchema(OozieBaseSchema):
     _property = ma.fields.List(
         ma.fields.Nested(OozieNameValueSchema),
         required=True,
-        load_from='property',
+        data_key='property',
         dump_to='property',
         attribute='property')
 
@@ -93,9 +93,9 @@ class OozieHadoopConfigurationSchema(OozieBaseSchema):
 class OozieMapReduceActionSchema(OozieBaseSchema):
     arg = ma.fields.List(ma.fields.String(), missing=[])
     configuration = ma.fields.Nested(OozieHadoopConfigurationSchema)
-    job_tracker = ma.fields.String(required=True, load_from='job-tracker')
-    name_node = ma.fields.String(required=True, load_from='name-node')
-    main_class = ma.fields.String(load_from='main-class')
+    job_tracker = ma.fields.String(required=True, data_key='job-tracker')
+    name_node = ma.fields.String(required=True, data_key='name-node')
+    main_class = ma.fields.String(data_key='main-class')
 
 
 class OozieMapReduceActionBuilder(OozieActionBuilderWithSchema):

--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -48,7 +48,7 @@ class BuildKubernetesSchema(StrictSchema):
     class_name = ma.fields.String(required=True)
 
     @ma.validates_schema
-    def check_valid_class(self, data):
+    def check_valid_class(self, data, **kwargs):
         ALLOWED_CLASS = ['airflow.contrib.kubernetes.volume.Volume',
                          'airflow.contrib.kubernetes.volume_mount.VolumeMount',
                          'airflow.contrib.kubernetes.secret.Secret',
@@ -89,7 +89,7 @@ class BuildTimedeltaSchema(StrictSchema):
     units = ma.fields.String(required=True)
 
     @ma.validates_schema
-    def check_valid_units(self, data):
+    def check_valid_units(self, data, **kwargs):
         ALLOWED_UNITS = ['seconds', 'minutes', 'hours', 'days']
         if data.get('units') not in ALLOWED_UNITS:
             raise ma.ValidationError(

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
         'jsonschema>=2.6.0,<3.0',
         'jinja2>=2.8.1,<3.0',
         'pyyaml>=4.2b1',
-        'marshmallow>=2.13.6,<3.0',
+        'marshmallow>=3.0,<4.0',
         'networkx>=2.1,<2.3',
         'xmltodict>=0.11.0,<1.0',
         'six>=1.11.0,<2.0',
@@ -63,5 +63,5 @@ setuptools.setup(
     license = 'Apache License 2.0',
     keywords = 'airflow',
     zip_safe = False,
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+    python_requires='>=3.5',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
-envlist = py27, py3, lint
+envlist = py3, lint
 
 [testenv]
+install_command=pip install --trusted-host=pypi.org --trusted-host=files.pythonhosted.org {opts} {packages}
 deps = pytest==3.8.1
        pytest-cov==2.6.0
        pytest-mock==1.10.0


### PR DESCRIPTION
Migration to marshmallow 3, specifically 3.6.1
Also removed python27 env from tox.

I am able to run all test successfully except below two test related to Oozie workflow. As I have very little understanding of Oozie workflow, not able to resolve these two. Any help would be really appreciated.

`test/oozier/test_oozie_converter.py::test_workflow_parser FAILED`                                                                                                                                                       
`test/oozier/test_oozie_converter.py::test_workflow_parser_with_prune_forks FAILED`


As boundary-layer master is for Python 2.7, and if you don't have plan to move to Python 3 as of now maybe we can create another branch for python3 changes and merge these changes to that.