### PR TITLE
Allow plugins to be used within generator sub-workflows

### DIFF
--- a/boundary_layer/schemas/dag.py
+++ b/boundary_layer/schemas/dag.py
@@ -93,6 +93,21 @@ class BaseDagSchema(StrictSchema):
     sub_dags = fields.List(fields.Nested(ReferenceSchema()))
     generators = fields.List(fields.Nested(GeneratorSchema()))
 
+    plugin_config = fields.Dict()
+
+    @validates_schema
+    def validate_plugin_config(self, data):
+        from boundary_layer import plugins
+        if 'plugin_config' not in data:
+            return
+
+        try:
+            plugins.manager.validate_config(data['plugin_config'])
+        except ValidationError as e:
+            raise e
+        except Exception as e:
+            raise ValidationError(str(e))
+
 
 class DagArgsSchema(StrictSchema):
     catchup = fields.Boolean(missing=True)
@@ -186,8 +201,6 @@ class PrimaryDagSchema(BaseDagSchema):
 
     default_task_args = fields.Dict()
 
-    plugin_config = fields.Dict()
-
     @validates_schema
     def validate_compatibility_version(self, data):
         if not data.get('compatibility_version'):
@@ -213,16 +226,3 @@ class PrimaryDagSchema(BaseDagSchema):
                 'is for the incompatible prior version {}. Use the '
                 'migrate-workflow script to update it.'.format(version),
                 ['compatibility_version'])
-
-    @validates_schema
-    def validate_plugin_config(self, data):
-        from boundary_layer import plugins
-        if 'plugin_config' not in data:
-            return
-
-        try:
-            plugins.manager.validate_config(data['plugin_config'])
-        except ValidationError as e:
-            raise e
-        except Exception as e:
-            raise ValidationError(str(e))

--- a/boundary_layer/workflow.py
+++ b/boundary_layer/workflow.py
@@ -325,18 +325,34 @@ class Workflow(object):
         if imports:
             parsed['imports'] = imports
 
-        default_task_args = parsed.get('default_task_args', {})
+        default_task_args = Workflow._get_default_task_args(parsed, schema_cls)
         default_task_args.update(
             plugins.manager.insert_default_task_args(plugin_config))
         if default_task_args:
             parsed['default_task_args'] = default_task_args
 
-        dag_args = parsed.get('dag_args', {})
+        dag_args = Workflow._get_dag_args(parsed, schema_cls)
         dag_args.update(plugins.manager.insert_dag_args(plugin_config))
         if dag_args:
             parsed['dag_args'] = dag_args
 
         return parsed
+
+    @staticmethod
+    def _get_default_task_args(parsed, schema_cls):
+        default_task_args = parsed.get('default_task_args', {})
+        if default_task_args:
+            if not issubclass(schema_cls, PrimaryDagSchema):
+                raise Exception('Invalid property default_task_args found in subdag')
+        return default_task_args
+
+    @staticmethod
+    def _get_dag_args(parsed, schema_cls):
+        dag_args = parsed.get('dag_args', {})
+        if dag_args:
+            if not issubclass(schema_cls, PrimaryDagSchema):
+                raise Exception('Invalid property dag_args found in subdag')
+        return dag_args
 
     def build_dag(
             self,

--- a/test/data/bad-dags/invalid_subdag_plugin_test.yaml
+++ b/test/data/bad-dags/invalid_subdag_plugin_test.yaml
@@ -1,0 +1,53 @@
+name: invalid-subdag-plugin-test
+
+dag_args:
+    schedule_interval: '@daily'
+
+default_task_args:
+    start_date: '2017-07-01'
+    retries: 2
+    owner: mgrit@etsy.com
+    project_id: my-project
+
+resources:
+    - name: dataproc_cluster
+      type: dataproc_cluster
+      properties:
+          cluster_name: my-cluster
+          region: us-central1
+          num_workers: 10
+          zone: us-central1-a
+before:
+    - name: SuccessFileSensor
+      type: gcs_object_sensor
+      properties:
+          bucket: my-bucket
+          object: my-object
+operators:
+- name: Datacopier
+  type: dataproc_hadoop
+  requires_resources:
+      - dataproc_cluster
+
+  properties:
+      main_class: distcp.DistCp
+      arguments:
+          - my-src
+          - my-dest
+
+sub_dags:
+    - name: tester
+      type: sub_dag
+      target: invalid-subdag-plugin-tester
+---
+name: invalid-subdag-plugin-tester
+
+dag_args:
+    schedule_interval: '@daily'
+
+operators:
+    - name: SubDagSuccessFileSensor
+      type: gcs_object_sensor
+      properties:
+          bucket: my-bucket
+          object: my-object


### PR DESCRIPTION
Allow plugins to be evaluated within generator sub-workflows so any operators that may be added by the plugin are added to the correct subgraph. 

usage:
```
name: my-dag

resources:
- name: dataproc-cluster
  type: dataproc_cluster
  properties:
    cluster_name: my-cluster-{{ execution_date.strftime('%s') }}
    num_workers: 10
    region: us-central1

default_task_args:
  start_date: '2020-05-17'

generators:
- name: my-generator
  type: list_generator
  target: my-sub-workflow
  properties:
    items:
      - item_a
      - item_b
---
name: my-sub-workflow

operators:
- name: my-job
  plugin_config:
    default:
      my_plugin: test
  type: dataproc_hadoop
  requires_resources:
  - dataproc-cluster
  properties:
    main_class: com.etsy.my.job.ClassName
    dataproc_hadoop_properties:
      mapreduce.map.output.compress: 'true'
    arguments: [ '--date', '{{ ds }}', '<<item_name>>' ]
```