### PR TITLE
delete unused jars field

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest .[github]
+        pip install flake8 pytest mock .[github]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest mock .[github]
+        pip install flake8 pytest mock pytest-mock .[github]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/boundary_layer/schemas/dag.py
+++ b/boundary_layer/schemas/dag.py
@@ -179,9 +179,6 @@ class DagArgsSchema(StrictSchema):
 class PrimaryDagSchema(BaseDagSchema):
     compatibility_version = fields.String()
 
-    # jars parameter is the list of jar URIs required by the workflow
-    jars = fields.List(fields.String())
-
     dag_args = fields.Nested(DagArgsSchema)
 
     default_task_args = fields.Dict()


### PR DESCRIPTION
While reviewing #58 I noticed that there is a field named `jars` on the `PrimaryDagSchema` that dates back to olden times...  this has probably never been used by boundary-layer in its current incarnation.  While I suppose in theory it is possible that somebody somewhere could be using this field from within a plugin, I find this highly unlikely.  So, let's remove it.  