### PR TITLE
[DATAGCP-1749] Fix schema_fields type in gcs_to_bigquery op

### DIFF
--- a/boundary_layer_default_plugin/config/operators/bigquery_create_table.yaml
+++ b/boundary_layer_default_plugin/config/operators/bigquery_create_table.yaml
@@ -1,0 +1,85 @@
+# Copyright 2018 Etsy Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+name: bigquery_create_table
+operator_class: BigQueryCreateEmptyTableOperator
+operator_class_module: airflow.contrib.operators.bigquery_operator
+schema_extends: base
+parameters_jsonschema:
+    properties:
+        dataset_id:
+            type: string
+        table_id:
+            type: string
+        project_id:
+            type: string
+        schema_fields:
+            type: array
+            items:
+                type: object
+                properties:
+                    name:
+                        type: string
+                    type:
+                        type: string
+                        enum: [
+                            STRING,
+                            BYTES,
+                            INTEGER,
+                            INT64,
+                            FLOAT,
+                            FLOAT64,
+                            BOOL,
+                            BOOLEAN,
+                            TIMESTAMP,
+                            DATE,
+                            TIME,
+                            DATETIME,
+                            RECORD,
+                            STRUCT
+                        ]
+                    mode:
+                        type: string
+                        enum: [ NULLABLE, REQUIRED, REPEATED ]
+                    fields:
+                        type: array
+                        items:
+                            type: object
+                    description:
+                        type: string
+                    policyTags:
+                        type: object
+                        properties:
+                            names:
+                                type: array
+                                items:
+                                    type: string
+        gcs_schema_object:
+            type: string
+        time_partitioning:
+            type: object
+            additionalProperties:
+                type: string
+        bigquery_conn_id:
+            type: string
+        google_cloud_storage_conn_id:
+            type: string
+        delegate_to:
+            type: string
+        labels:
+            type: object
+    required:
+        - dataset_id
+        - table_id
+        - project_id

--- a/boundary_layer_default_plugin/config/operators/gcs_to_bigquery.yaml
+++ b/boundary_layer_default_plugin/config/operators/gcs_to_bigquery.yaml
@@ -49,7 +49,44 @@ parameters_jsonschema:
         schema_fields:
             type: array
             items:
-                type: string
+                type: object
+                properties:
+                    name:
+                        type: string
+                    type:
+                        type: string
+                        enum: [
+                            STRING,
+                            BYTES,
+                            INTEGER,
+                            INT64,
+                            FLOAT,
+                            FLOAT64,
+                            BOOL,
+                            BOOLEAN,
+                            TIMESTAMP,
+                            DATE,
+                            TIME,
+                            DATETIME,
+                            RECORD,
+                            STRUCT
+                        ]
+                    mode:
+                        type: string
+                        enum: [ NULLABLE, REQUIRED, REPEATED ]
+                    fields:
+                        type: array
+                        items:
+                            type: object
+                    description:
+                        type: string
+                    policyTags:
+                        type: object
+                        properties:
+                            names:
+                                type: array
+                                items:
+                                    type: string
         schema_object:
             type: string
         quote_character:


### PR DESCRIPTION
The schema_fields property should be an array of types per the spec described by BigQuery [here](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#TableFieldSchema).

Tested this change locally w/ an editable pip list and this dag in development:

```sh
[dags (vchiapaikeo/test-loading-tsv-to-dbs-v1) x]> pip list
Package                    Version     Location
-------------------------- ----------- --------------------------------------------
boundary-layer             1.7.17.dev0 /home/vchiapaikeo/development/boundary-layer
boundary-layer-etsy-plugin 1.7.71
cachetools                 4.1.1
certifi                    2020.6.20
chardet                    3.0.4
decorator                  4.4.2
etsy-dag-client            0.3.69
future                     0.16.0
google-api-core            1.21.0
google-auth                1.18.0
google-cloud-core          1.3.0
google-cloud-storage       1.29.0
google-resumable-media     0.5.1
googleapis-common-protos   1.52.0
idna                       2.10
Jinja2                     2.11.2
jsonschema                 2.6.0
MarkupSafe                 1.1.1
marshmallow                2.21.0
networkx                   2.2
pip                        20.1.1
protobuf                   3.12.2
pyasn1                     0.4.8
pyasn1-modules             0.2.8
pytz                       2020.1
PyYAML                     5.3.1
requests                   2.24.0
rsa                        4.6
semver                     2.10.2
setuptools                 49.1.0
six                        1.15.0
tabulate                   0.7.7
uritools                   3.0.0
urllib3                    1.25.9
wheel                      0.34.2
xmltodict                  0.12.0
```

```yaml
operators:
- name: load_to_bigquery
  type: gcs_to_bigquery
  properties:
    bucket: XYZ
    source_objects:
      - 'gcp-generic-sink/analytics.etsy.com/test_jobs.TestTaxonomyNodesJob/vchiapaikeo.taxonomy_nodes/2020_07_07/part*'
    source_format: CSV
    field_delimiter: '\t'
    destination_project_dataset_table: <<os.getenv('GOOGLE_CLOUD_PROJECT')>>.analytics.vchiapaikeo_taxonomy_nodes$20200707
    create_disposition: CREATE_IF_NEEDED
    write_disposition: WRITE_TRUNCATE
    compression: NONE
    skip_leading_rows: 0
    max_bad_records: 0
    src_fmt_configs:
      nullMarker: 'null'
    allow_jagged_rows: false
    autodetect: false
    schema_fields:
      - name: taxonomy_id
        type: INT64
        mode: NULLABLE
      - name: parent_taxonomy
        type: INT64
        mode: NULLABLE
      - name: run_date
        type: INT64
        mode: NULLABLE
    cluster_fields:
      - run_date
```

Translates to:

```py
import os
import re
from airflow import DAG

import datetime

from etsy_airflow_plugins.datacop.failure_handler import configured_datacop_handler
from airflow.contrib.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator

DEFAULT_TASK_ARGS = {
        'owner': 'gcp-data-platform',
        'start_date': '2020-07-06',
        'retries': 1,
        'retry_exponential_backoff': True,
        'project_id': (os.getenv('GOOGLE_CLOUD_PROJECT')),
        'on_failure_callback': (configured_datacop_handler()),
        'dataproc_hadoop_jars': ['{{ macros.etsy.latest_build_jar(task) }}'],
    }

dag = DAG(
        max_active_runs = 1,
        schedule_interval = '@daily',
        catchup = False,
        dag_id = 'vchiapaikeo_scalding_sink_test',
        default_args = DEFAULT_TASK_ARGS,
    )

load_to_bigquery = GoogleCloudStorageToBigQueryOperator(
        autodetect = False,
        source_objects = ['gcp-generic-sink/analytics.etsy.com/test_jobs.TestTaxonomyNodesJob/vchiapaikeo.taxonomy_nodes/2020_07_07/part*'],
        compression = 'NONE',
        src_fmt_configs = { 'nullMarker': 'null' },
        bucket = 'XYZ',
        create_disposition = 'CREATE_IF_NEEDED',
        destination_project_dataset_table = ((os.getenv('GOOGLE_CLOUD_PROJECT')) + '.analytics.vchiapaikeo_taxonomy_nodes$20200707'),
        cluster_fields = ['run_date'],
        dag = (dag),
        task_id = 'load_to_bigquery',
        field_delimiter = '\t',
        write_disposition = 'WRITE_TRUNCATE',
        start_date = (datetime.datetime(2020, 7, 6, 0, 0)),
        schema_fields = [{ 'name': 'taxonomy_id','type': 'INT64','mode': 'NULLABLE' },{ 'name': 'parent_taxonomy','type': 'INT64','mode': 'NULLABLE' },{ 'name': 'run_date','type': 'INT64','mode': 'NULLABLE' }],
        max_bad_records = 0,
        skip_leading_rows = 0,
        source_format = 'CSV',
        allow_jagged_rows = False,
    )
```

With a proper schema:

![image](https://user-images.githubusercontent.com/9200263/87109107-c905ad80-c231-11ea-9218-8790a0103c68.png)

With an improper schema:

```
[dags (vchiapaikeo/test-loading-tsv-to-dbs-v1) x]> dag_client --host https://airflow-dev-dot-etsy-hadoop-sandbox-dev.appspot.com test vchiapaikeo_scalding_sink_test.yaml
2020-07-10 13:35:33,834 - boundary-layer v. 1.7.17-dev0 - INFO - Loaded plugins etsy, default
/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/google/auth/_default.py:69: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a "quota exceeded" or "API not enabled" error. We recommend you rerun `gcloud auth application-default login` and make sure a quota project is added. Or you can use service accounts instead. For more information about service accounts, see https://cloud.google.com/docs/authentication/
  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
INFO:root:Converting yaml file vchiapaikeo_scalding_sink_test.yaml to /tmp/tmpr0vndibt/vchiapaikeo_scalding_sink_test-872e1a8f.py
Traceback (most recent call last):
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/etsy_dag_client/client.py", line 187, in _prepare_file
    wf = Workflow.load(path)
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/workflow.py", line 56, in load
    yaml_config=content,
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/workflow.py", line 65, in __init__
    self.specs = self._build_specs()
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/workflow.py", line 95, in _build_specs
    Workflow.validate_and_resolve_properties(parsed_spec)
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/workflow.py", line 246, in validate_and_resolve_properties
    validate_dag(spec.primary, ExecutionContext(referrer=None, resources={}))
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/workflow.py", line 229, in validate_dag
    preprocessor_loader=plugins.manager.property_preprocessors,
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/registry/types/operator.py", line 154, in resolve_properties
    schema=schema)
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/validator.py", line 47, in validate_and_fill_defaults
    DefaultValidatingDraft4Validator(schema).validate(copy)
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/jsonschema/validators.py", line 130, in validate
    raise error
jsonschema.exceptions.ValidationError: 'INT64D' is not one of ['STRING', 'BYTES', 'INTEGER', 'INT64', 'FLOAT', 'FLOAT64', 'BOOLEAN', 'TIMESTAMP', 'DATE', 'TIME', 'DATETIME', 'RECORD', 'STRUCT']

Failed validating 'enum' in schema['properties']['schema_fields']['items']['properties']['type']:
    {'enum': ['STRING',
              'BYTES',
              'INTEGER',
              'INT64',
              'FLOAT',
              'FLOAT64',
              'BOOLEAN',
              'TIMESTAMP',
              'DATE',
              'TIME',
              'DATETIME',
              'RECORD',
              'STRUCT'],
     'type': 'string'}

On instance['schema_fields'][0]['type']:
    'INT64D'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/bin/dag_client", line 284, in <module>
    COMMAND_MAPPINGS[args.cmd](args)
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/bin/dag_client", line 88, in do_submit_or_test
    else get_client(args).test_files(args.files)
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/etsy_dag_client/client.py", line 47, in test_files
    return self._post_files_with_hashes(endpoint = '/test_dags', paths = paths)
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/etsy_dag_client/client.py", line 231, in _post_files_with_hashes
    self._prepare_file(p, tempdir) for p in paths ])
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/etsy_dag_client/client.py", line 231, in <listcomp>
    self._prepare_file(p, tempdir) for p in paths ])
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/etsy_dag_client/client.py", line 196, in _prepare_file
    path, str(e)))
Exception: Error converting yaml file vchiapaikeo_scalding_sink_test.yaml: 'INT64D' is not one of ['STRING', 'BYTES', 'INTEGER', 'INT64', 'FLOAT', 'FLOAT64', 'BOOLEAN', 'TIMESTAMP', 'DATE', 'TIME', 'DATETIME', 'RECORD', 'STRUCT']

Failed validating 'enum' in schema['properties']['schema_fields']['items']['properties']['type']:
    {'enum': ['STRING',
              'BYTES',
              'INTEGER',
              'INT64',
              'FLOAT',
              'FLOAT64',
              'BOOLEAN',
              'TIMESTAMP',
              'DATE',
              'TIME',
              'DATETIME',
              'RECORD',
              'STRUCT'],
     'type': 'string'}

On instance['schema_fields'][0]['type']:
    'INT64D'
[dags (vchiapaikeo/test-loading-tsv-to-dbs-v1) x]>
[dags (vchiapaikeo/test-loading-tsv-to-dbs-v1) x]>
[dags (vchiapaikeo/test-loading-tsv-to-dbs-v1) x]> dag_client --host https://airflow-dev-dot-etsy-hadoop-sandbox-dev.appspot.com test vchiapaikeo_scalding_sink_test.yaml
2020-07-10 13:36:23,954 - boundary-layer v. 1.7.17-dev0 - INFO - Loaded plugins etsy, default
/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/google/auth/_default.py:69: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a "quota exceeded" or "API not enabled" error. We recommend you rerun `gcloud auth application-default login` and make sure a quota project is added. Or you can use service accounts instead. For more information about service accounts, see https://cloud.google.com/docs/authentication/
  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
INFO:root:Converting yaml file vchiapaikeo_scalding_sink_test.yaml to /tmp/tmpqldswks_/vchiapaikeo_scalding_sink_test-25be9b6c.py
Traceback (most recent call last):
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/etsy_dag_client/client.py", line 187, in _prepare_file
    wf = Workflow.load(path)
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/workflow.py", line 56, in load
    yaml_config=content,
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/workflow.py", line 65, in __init__
    self.specs = self._build_specs()
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/workflow.py", line 95, in _build_specs
    Workflow.validate_and_resolve_properties(parsed_spec)
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/workflow.py", line 246, in validate_and_resolve_properties
    validate_dag(spec.primary, ExecutionContext(referrer=None, resources={}))
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/workflow.py", line 229, in validate_dag
    preprocessor_loader=plugins.manager.property_preprocessors,
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/registry/types/operator.py", line 154, in resolve_properties
    schema=schema)
  File "/home/vchiapaikeo/development/boundary-layer/boundary_layer/validator.py", line 47, in validate_and_fill_defaults
    DefaultValidatingDraft4Validator(schema).validate(copy)
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/jsonschema/validators.py", line 130, in validate
    raise error
jsonschema.exceptions.ValidationError: 'NULLABLEB' is not one of ['NULLABLE', 'REQUIRED', 'REPEATED']

Failed validating 'enum' in schema['properties']['schema_fields']['items']['properties']['mode']:
    {'enum': ['NULLABLE', 'REQUIRED', 'REPEATED'], 'type': 'string'}

On instance['schema_fields'][0]['mode']:
    'NULLABLEB'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/bin/dag_client", line 284, in <module>
    COMMAND_MAPPINGS[args.cmd](args)
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/bin/dag_client", line 88, in do_submit_or_test
    else get_client(args).test_files(args.files)
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/etsy_dag_client/client.py", line 47, in test_files
    return self._post_files_with_hashes(endpoint = '/test_dags', paths = paths)
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/etsy_dag_client/client.py", line 231, in _post_files_with_hashes
    self._prepare_file(p, tempdir) for p in paths ])
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/etsy_dag_client/client.py", line 231, in <listcomp>
    self._prepare_file(p, tempdir) for p in paths ])
  File "/home/vchiapaikeo/development/BigDataConf/projects/etsy-hadoop-sandbox-dev/services/airflow-dev/venv/lib/python3.6/site-packages/etsy_dag_client/client.py", line 196, in _prepare_file
    path, str(e)))
Exception: Error converting yaml file vchiapaikeo_scalding_sink_test.yaml: 'NULLABLEB' is not one of ['NULLABLE', 'REQUIRED', 'REPEATED']

Failed validating 'enum' in schema['properties']['schema_fields']['items']['properties']['mode']:
    {'enum': ['NULLABLE', 'REQUIRED', 'REPEATED'], 'type': 'string'}

On instance['schema_fields'][0]['mode']:
    'NULLABLEB'

```