### PR TITLE
Enable publish on tag

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,9 +30,9 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 boundary_layer boundary_layer_default_plugin bin test --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 boundary_layer boundary_layer_default_plugin bin test --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         pytest test

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,13 +4,17 @@
 name: Upload Python Package
 
 on:
-  release:
-    types: [created]
+  create:
+    tags:
+    - '*'
 
 jobs:
   deploy:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.7]
 
     steps:
     - uses: actions/checkout@v2
@@ -19,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,9 +12,6 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.7]
 
     steps:
     - uses: actions/checkout@v2
@@ -23,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ optional arguments:
 ```
 
 ## Publishing updates to PyPI (admins only)
-`boundary-layer` is distributed via [PyPI](https://pypi.org/project/boundary-layer/).  We rely on an automated Github Actions [build](.github/workflows/python-publish.yaml) to publish updates.  The build runs every time a tag is pushed to the repository.  We have a [script](release.py) that automates the creation of these tags, making sure that they are versioned correctly and created for the intended commits.
+`boundary-layer` is distributed via [PyPI](https://pypi.org/project/boundary-layer/).  We rely on an automated Github Actions [build](.github/workflows/python-publish.yml) to publish updates.  The build runs every time a tag is pushed to the repository.  We have a [script](release.py) that automates the creation of these tags, making sure that they are versioned correctly and created for the intended commits.
 
 The recommended process for publishing a relatively minor boundary layer update is to simply run
 ```

--- a/README.md
+++ b/README.md
@@ -69,20 +69,23 @@ There are a few other options supported by the `release.py` command, as describe
 ╰$ ./release.py --help
 usage: release.py [-h]
                   [--bump {major,minor,patch} | --force-version FORCE_VERSION]
-                  [--remote-branch-name REMOTE_BRANCH_NAME]
                   [--git-remote-name GIT_REMOTE_NAME]
+                  [--remote-branch-name REMOTE_BRANCH_NAME]
 
 optional arguments:
   -h, --help            show this help message and exit
   --bump {major,minor,patch}
+                        Select the portion of the version string to bump.
+                        default: `patch`
   --force-version FORCE_VERSION
                         Force the new version to this value. Must be a valid
                         semver.
+  --git-remote-name GIT_REMOTE_NAME
+                        Name of the git remote from which to release. default:
+                        `origin`
   --remote-branch-name REMOTE_BRANCH_NAME
                         Name of the remote branch to use as the basis for the
-                        release
-  --git-remote-name GIT_REMOTE_NAME
-                        Name of the git remote from which to release
+                        release. default: `master`
 ```
 
 # boundary-layer YAML configs

--- a/README.md
+++ b/README.md
@@ -48,6 +48,43 @@ optional arguments:
   -h, --help            show this help message and exit
 ```
 
+## Publishing updates to PyPI (admins only)
+`boundary-layer` is distributed via [PyPI](https://pypi.org/project/boundary-layer/).  We rely on an automated Github Actions [build](.github/workflows/python-publish.yaml) to publish updates.  The build runs every time a tag is pushed to the repository.  We have a [script](release.py) that automates the creation of these tags, making sure that they are versioned correctly and created for the intended commits.
+
+The recommended process for publishing a relatively minor boundary layer update is to simply run
+```
+./release.py
+```
+which will bump the patch version.
+
+For bigger changes, you can bump the minor (or major) versions, or you can force a specific version string, via one of the following commands:
+```
+./release.py --bump minor
+./release.py --bump major
+./release.py --force-version a.b.c
+```
+
+There are a few other options supported by the `release.py` command, as described by the usage string:
+```
+╰$ ./release.py --help
+usage: release.py [-h]
+                  [--bump {major,minor,patch} | --force-version FORCE_VERSION]
+                  [--remote-branch-name REMOTE_BRANCH_NAME]
+                  [--git-remote-name GIT_REMOTE_NAME]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --bump {major,minor,patch}
+  --force-version FORCE_VERSION
+                        Force the new version to this value. Must be a valid
+                        semver.
+  --remote-branch-name REMOTE_BRANCH_NAME
+                        Name of the remote branch to use as the basis for the
+                        release
+  --git-remote-name GIT_REMOTE_NAME
+                        Name of the git remote from which to release
+```
+
 # boundary-layer YAML configs
 The primary feature of boundary-layer is its ability to build python DAGs from simple, structured YAML files.
 
@@ -181,7 +218,7 @@ This python DAG is now ready for ingestion directly into a running Airflow insta
 A few things to note:
  - `boundary-layer` converted the `start_date` parameter from a string to a python `datetime` object.  This is an example of the boundary-layer argument-preprocessor feature, which allows config parameters to be specified as user-friendly strings and converted to the necessary python data structures automatically.
  - `boundary-layer` added a `sentinel` node in parallel with the cluster-destroy node, which serves as an indicator to Airflow itself regarding the ultimate outcome of the Dag Run.  Airflow determines the Dag Run status from the leaf nodes of the DAG, and normally the cluster-destroy node will always execute (irrespective of upstream failures) and will likely succeed. This would cause DAGs with failures in critical nodes to be marked as successes, if not for the sentinel node.  The sentinel node will only trigger if all of its upstream dependencies succeed --- otherwise it will be marked as `upstream-failed`, which induces a failure state for the Dag Run.
- 
+
 # Oozie Migration tools
 
 In addition to allowing us to define Airflow workflows using YAML configurations, `boundary-layer` also provides a module for converting Oozie XML configuration files into `boundary-layer` YAML configurations, which can then be used to create Airflow DAGs.

--- a/release.py
+++ b/release.py
@@ -9,7 +9,7 @@ To create a release, run:
 
 This will:
     1. Fetch the remote state of the repository, to make sure that you have an up-to-date copy
-    2. If your local branch is set up to track the remote master branch, check to make sure that your local branch is in-sync with the remote, to help prevent you from executing a release that fails to capture your desired changes
+    2. Run some checks on your local state, comparing it to the remote state, to help prevent you from executing a release that fails to capture your desired changes
     3. Check out the local copy of the remote state
     4. Create a tag
     5. Push the tag
@@ -32,7 +32,7 @@ def build_parser():
         '--bump',
         choices=['major', 'minor', 'patch'],
         default='patch',
-
+        help='Select the portion of the version string to bump. default: `patch`'
     )
     bump_type.add_argument(
         '--force-version',
@@ -41,15 +41,15 @@ def build_parser():
     )
 
     parser.add_argument(
-        '--remote-branch-name',
-        default='master',
-        help='Name of the remote branch to use as the basis for the release'
+        '--git-remote-name',
+        default='origin',
+        help='Name of the git remote from which to release. default: `origin`'
     )
 
     parser.add_argument(
-        '--git-remote-name',
-        default='origin',
-        help='Name of the git remote from which to release'
+        '--remote-branch-name',
+        default='master',
+        help='Name of the remote branch to use as the basis for the release. default: `master`'
     )
 
     return parser

--- a/release.py
+++ b/release.py
@@ -167,7 +167,7 @@ def do_release(*, remote_name, branch_name, bump_type, force_version):
     current_branch = get_current_branch()
     if current_branch.get('remote') == f'{remote_name}/{branch_name}' and current_branch.get('ahead_behind'):
         raise Exception(
-            'Local changes found on branch that tracks the remote that we are publishing!  This is probably an error'
+            'Local changes found on branch that tracks the remote that we are publishing!  This is probably unintended.  Please reconcile your local state before proceeding.'
         )
 
     try:

--- a/release.py
+++ b/release.py
@@ -1,0 +1,131 @@
+import argparse
+import shlex
+import subprocess
+import semver
+from versioneer import get_version
+
+def build_parser():
+    parser = argparse.ArgumentParser()
+
+    bump_type = parser.add_mutually_exclusive_group()
+    bump_type.add_argument(
+        '--bump',
+        choices=['major', 'minor', 'patch'],
+        default='patch',
+
+    )
+    bump_type.add_argument(
+        '--force-version',
+        type=semver.VersionInfo.parse,
+        help='Force the new version to this value.  Must be a valid semver.'
+    )
+
+    parser.add_argument(
+        '--remote-branch-name',
+        default='master',
+        help='Name of the remote branch to use as the basis for the release'
+    )
+
+    parser.add_argument(
+        '--git-remote-name',
+        default='origin',
+        help='Name of the git remote from which to release'
+    )
+
+    return parser
+
+
+def bump_version(version, bump_type):
+    bumpers = {
+        'major': semver.bump_major,
+        'minor': semver.bump_minor,
+        'patch': semver.bump_patch,
+    }
+
+    return bumpers[bump_type](str(version))
+
+
+def check_remote(remote_name):
+    output = subprocess.check_output(
+        shlex.split(f'git remote get-url {remote_name}'),
+        encoding='utf-8'
+    ).strip()
+
+    if output not in [
+        'git@github.com:etsy/boundary-layer',
+        'https://github.com/etsy/boundary-layer',
+        'https://www.github.com/etsy/boundary-layer',
+    ]:
+        print(f'''
+    WARNING: Remote `{remote_name}` corresponding to `{output}` will not trigger the release build!
+    We recommend releasing to `git@github.com:etsy/boundary-layer`''')
+
+
+def fetch_latest(remote_name, branch_name):
+    print(f'Fetching latest commits from {remote_name}/{branch_name}')
+    subprocess.check_call(
+        shlex.split(
+            f'git fetch {remote_name} {branch_name}'
+        )
+    )
+
+
+def git_checkout(remote_name, branch_name):
+    print(f'Checking out {remote_name}/{branch_name}')
+    subprocess.check_call(
+        shlex.split(
+            f'git checkout {remote_name}/{branch_name}'
+        )
+    )
+
+
+def check_git_state():
+    output = subprocess.check_output(
+        shlex.split('git status --porcelain'),
+        encoding='utf-8'
+    ).strip()
+    if output:
+        raise Exception(
+            f'Cannot release: unclean git state:\n{output}'
+        )
+
+
+def push_tag(tag_name):
+    print('Creating tag')
+    subprocess.check_call(
+        shlex.split(
+            f'''
+                git tag -a -m "Bumping to version {tag_name}" {tag_name}
+            '''
+        )
+    )
+
+    print('Pushing tag')
+    #subprocess.check_call(
+    #    shlex.split(
+    #        f'''
+    #            git push --tags
+    #        '''
+    #    )
+    #)
+    print('Tag pushed successfully.')
+
+
+def verify_and_push_tag(remote_name, branch_name, tag_version):
+    check_remote(remote_name)
+    fetch_latest(remote_name, branch_name)
+    git_checkout(remote_name, branch_name)
+    check_git_state(remote_name, branch_name)
+    push_tag(version)
+
+
+if __name__ == '__main__':
+    parser = build_parser()
+    args = parser.parse_args()
+    current_version = semver.VersionInfo.parse(get_version())
+
+    print(f'Current version is: {current_version}')
+
+    new_version = str(args.force_version) or bump_version(current_version, args.bump)
+    print('New version: {}'.format(new_version))
+    verify_and_push_tag(args.git_remote_name, args.remote_branch_name, new_version)

--- a/release.py
+++ b/release.py
@@ -141,6 +141,7 @@ def create_and_push_tag(remote_name, tag_name):
 def parse_current_branch(state):
     # state.branch has the form
     # `## <branch-name>...<upstream> [<ahead|behind> <number-of-commits>]`
+    # bu the upstream portion and the ahead/behind are all optional
 
     pattern = r'## (?P<branch_name>[a-zA-Z0-9_/-]+)(\.\.\.(?P<remote>[a-z0-9A-Z_/-]+)( \[(?P<ahead_behind>(ahead|behind) \d+)\])?)?'
     m = re.match(pattern, state.branch).groupdict()

--- a/release.py
+++ b/release.py
@@ -171,7 +171,7 @@ def do_release(*, remote_name, branch_name, bump_type, force_version):
     check_remote(remote_name)
     fetch_latest(remote_name, branch_name)
 
-    current_branch = get_current_branch(get_git_state())
+    current_branch = parse_current_branch(get_git_state())
     if current_branch.remote == f'{remote_name}/{branch_name}' and current_branch.ahead_behind:
         raise Exception(
             f'Local changes found on branch `{current_branch.name}` which tracks `{remote_name}/{branch_name}`!  This is probably unintended.  Please reconcile your local state before proceeding.'

--- a/release.py
+++ b/release.py
@@ -90,7 +90,7 @@ def check_git_state():
 
 
 def push_tag(tag_name):
-    print('Creating tag {tag_name}')
+    print(f'Creating tag {tag_name}')
     subprocess.check_call(
         shlex.split(
             f'''
@@ -99,7 +99,7 @@ def push_tag(tag_name):
         )
     )
 
-    print('Pushing tag {tag_name}')
+    print(f'Pushing tag {tag_name}')
     #subprocess.check_call(
     #    shlex.split(
     #        f'''

--- a/release.py
+++ b/release.py
@@ -128,13 +128,13 @@ def create_and_push_tag(remote_name, tag_name):
     )
 
     print(f'Pushing tag {tag_name}')
-    #subprocess.check_call(
-    #    shlex.split(
-    #        f'''
-    #            git push --tags {remote_name}
-    #        '''
-    #    )
-    #)
+    subprocess.check_call(
+        shlex.split(
+            f'''
+                git push --tags {remote_name}
+            '''
+        )
+    )
     print('Tag pushed successfully.')
 
 

--- a/release.py
+++ b/release.py
@@ -137,10 +137,8 @@ def get_current_branch():
     # at this point, output has the form
     # `## <branch-name>...<upstream> [<ahead|behind> <number-of-commits>]`
 
-    m = re.match(
-        r'## (?P<branch_name>[a-zA-Z0-9_/-]+)(\.\.\.(?P<remote>[a-z0-9A-Z_/-]+) (\[(?P<ahead_behind>(ahead|behind) \d+)\])?)?',
-        output
-    )
+    pattern = r'## (?P<branch_name>[a-zA-Z0-9_/-]+)(\.\.\.(?P<remote>[a-z0-9A-Z_/-]+)( \[(?P<ahead_behind>(ahead|behind) \d+)\])?)?'
+    m = re.match(pattern, output)
 
     return m.groupdict()
 
@@ -167,7 +165,7 @@ def do_release(*, remote_name, branch_name, bump_type, force_version):
     current_branch = get_current_branch()
     if current_branch.get('remote') == f'{remote_name}/{branch_name}' and current_branch.get('ahead_behind'):
         raise Exception(
-            'Local changes found on branch that tracks the remote that we are publishing!  This is probably unintended.  Please reconcile your local state before proceeding.'
+            f'Local changes found on branch `{current_branch.get("branch_name")}` which tracks `{remote_name}/{branch_name}`!  This is probably unintended.  Please reconcile your local state before proceeding.'
         )
 
     try:

--- a/release.py
+++ b/release.py
@@ -113,7 +113,7 @@ def get_git_state():
 def check_git_state(state):
     if state.files:
         raise Exception(
-            f'Cannot release: unclean git state:\n{output}'
+            f'Cannot release: unclean git state:\n{state.files}'
         )
 
 

--- a/release.py
+++ b/release.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 import re
 import shlex

--- a/release.py
+++ b/release.py
@@ -139,7 +139,7 @@ def verify_and_push_tag(remote_name, branch_name, tag_version):
     try:
         git_checkout(remote_name, branch_name)
         check_git_state()
-        push_tag(version)
+        push_tag(tag_version)
     finally:
         original_branch = current_branch.get('branch_name')
         if original_branch:

--- a/release.py
+++ b/release.py
@@ -18,6 +18,7 @@ This will:
 Once the tag is created remotely, a github actions workflow should run the publish build, and release the new version of boundary-layer to pypi.
 """
 import argparse
+from collections import namedtuple
 import re
 import shlex
 import subprocess
@@ -97,12 +98,20 @@ def git_checkout(remote_name, branch_name):
     subprocess.check_call(shlex.split(f'git checkout {ref}'))
 
 
-def check_git_state():
+def get_git_state():
     output = subprocess.check_output(
-        shlex.split('git status --porcelain'),
+        shlex.split('git status -b --porcelain'),
         encoding='utf-8'
-    ).strip()
-    if output:
+    ).strip().split('\n')
+
+    return namedtuple('GitState', ['branch', 'files'])(
+        branch=output_lines[0],
+        files=output_lines[1:],
+    )
+
+
+def check_git_state(state):
+    if state.files:
         raise Exception(
             f'Cannot release: unclean git state:\n{output}'
         )
@@ -129,18 +138,18 @@ def create_and_push_tag(remote_name, tag_name):
     print('Tag pushed successfully.')
 
 
-def get_current_branch():
-    output = subprocess.check_output(
-        shlex.split('git status -b --porcelain'), encoding='utf-8'
-    ).strip().split('\n')[0]
-
-    # at this point, output has the form
+def parse_current_branch(state):
+    # state.branch has the form
     # `## <branch-name>...<upstream> [<ahead|behind> <number-of-commits>]`
 
     pattern = r'## (?P<branch_name>[a-zA-Z0-9_/-]+)(\.\.\.(?P<remote>[a-z0-9A-Z_/-]+)( \[(?P<ahead_behind>(ahead|behind) \d+)\])?)?'
-    m = re.match(pattern, output)
+    m = re.match(pattern, state.branch).groupdict()
 
-    return m.groupdict()
+    return namedtuple('GitBranch', ['name', 'remote', 'ahead_behind'])(
+        m.get('branch_name'),
+        m.get('remote'),
+        m.get('ahead_behind')
+    )
 
 
 def get_version(bump_type, force_version):
@@ -162,23 +171,22 @@ def do_release(*, remote_name, branch_name, bump_type, force_version):
     check_remote(remote_name)
     fetch_latest(remote_name, branch_name)
 
-    current_branch = get_current_branch()
-    if current_branch.get('remote') == f'{remote_name}/{branch_name}' and current_branch.get('ahead_behind'):
+    current_branch = get_current_branch(get_git_state())
+    if current_branch.remote == f'{remote_name}/{branch_name}' and current_branch.ahead_behind:
         raise Exception(
-            f'Local changes found on branch `{current_branch.get("branch_name")}` which tracks `{remote_name}/{branch_name}`!  This is probably unintended.  Please reconcile your local state before proceeding.'
+            f'Local changes found on branch `{current_branch.name}` which tracks `{remote_name}/{branch_name}`!  This is probably unintended.  Please reconcile your local state before proceeding.'
         )
 
     try:
         git_checkout(remote_name, branch_name)
-        check_git_state()
+        check_git_state(get_git_state())
         create_and_push_tag(
             remote_name,
             tag_name=get_version(bump_type, force_version),
         )
     finally:
-        original_branch = current_branch.get('branch_name')
-        if original_branch:
-            git_checkout(None, original_branch)
+        if current_branch.name:
+            git_checkout(None, current_branch.name)
 
 
 if __name__ == '__main__':

--- a/release.py
+++ b/release.py
@@ -90,7 +90,7 @@ def check_git_state():
         )
 
 
-def push_tag(tag_name):
+def push_tag(remote_name, tag_name):
     print(f'Creating tag {tag_name}')
     subprocess.check_call(
         shlex.split(
@@ -101,13 +101,13 @@ def push_tag(tag_name):
     )
 
     print(f'Pushing tag {tag_name}')
-    #subprocess.check_call(
-    #    shlex.split(
-    #        f'''
-    #            git push --tags
-    #        '''
-    #    )
-    #)
+    subprocess.check_call(
+        shlex.split(
+            f'''
+                git push --tags {remote_name}
+            '''
+        )
+    )
     print('Tag pushed successfully.')
 
 
@@ -140,7 +140,7 @@ def verify_and_push_tag(remote_name, branch_name, tag_version):
     try:
         git_checkout(remote_name, branch_name)
         check_git_state()
-        push_tag(tag_version)
+        push_tag(remote_name, tag_version)
     finally:
         original_branch = current_branch.get('branch_name')
         if original_branch:

--- a/release.py
+++ b/release.py
@@ -128,13 +128,13 @@ def create_and_push_tag(remote_name, tag_name):
     )
 
     print(f'Pushing tag {tag_name}')
-    subprocess.check_call(
-        shlex.split(
-            f'''
-                git push --tags {remote_name}
-            '''
-        )
-    )
+    #subprocess.check_call(
+    #    shlex.split(
+    #        f'''
+    #            git push --tags {remote_name}
+    #        '''
+    #    )
+    #)
     print('Tag pushed successfully.')
 
 

--- a/release.py
+++ b/release.py
@@ -1,7 +1,21 @@
 #!/usr/bin/env python3
 """
 
-This script is used for releasing boundary-layer.
+This script is used for releasing boundary-layer.  It can only be run by
+administrators of the repository at github.com/etsy/boundary-layer.
+
+To create a release, run:
+    ./release.py
+
+This will:
+    1. Fetch the remote state of the repository, to make sure that you have an up-to-date copy
+    2. If your local branch is set up to track the remote master branch, check to make sure that your local branch is in-sync with the remote, to help prevent you from executing a release that fails to capture your desired changes
+    3. Check out the local copy of the remote state
+    4. Create a tag
+    5. Push the tag
+    6. Return you to whatever branch you were on previously
+
+Once the tag is created remotely, a github actions workflow should run the publish build, and release the new version of boundary-layer to pypi.
 """
 import argparse
 import re

--- a/release.py
+++ b/release.py
@@ -155,4 +155,9 @@ if __name__ == '__main__':
 
     new_version = str(args.force_version) if args.force_version else bump_version(current_version, args.bump)
     print('New version: {}'.format(new_version))
-    verify_and_push_tag(args.git_remote_name, args.remote_branch_name, new_version)
+
+    okay = input('Continue? [y/N] ')
+    if okay.lower().startswith('y'):
+        verify_and_push_tag(args.git_remote_name, args.remote_branch_name, new_version)
+    else:
+        print('Aborting.')

--- a/release.py
+++ b/release.py
@@ -90,7 +90,7 @@ def check_git_state():
 
 
 def push_tag(tag_name):
-    print('Creating tag')
+    print('Creating tag {tag_name}')
     subprocess.check_call(
         shlex.split(
             f'''
@@ -99,7 +99,7 @@ def push_tag(tag_name):
         )
     )
 
-    print('Pushing tag')
+    print('Pushing tag {tag_name}')
     #subprocess.check_call(
     #    shlex.split(
     #        f'''

--- a/release.py
+++ b/release.py
@@ -99,7 +99,7 @@ def git_checkout(remote_name, branch_name):
 
 
 def get_git_state():
-    output = subprocess.check_output(
+    output_lines = subprocess.check_output(
         shlex.split('git status -b --porcelain'),
         encoding='utf-8'
     ).strip().split('\n')

--- a/release.py
+++ b/release.py
@@ -72,9 +72,9 @@ def fetch_latest(remote_name, branch_name):
 
 
 def git_checkout(remote_name, branch_name):
-    print(f'Checking out {remote_name}/{branch_name}')
-
     ref = f'{remote_name}/{branch_name}' if remote_name else branch_name
+    print(f'Checking out {ref}')
+
     subprocess.check_call(shlex.split(f'git checkout {ref}'))
 
 
@@ -153,6 +153,6 @@ if __name__ == '__main__':
 
     print(f'Current version is: {current_version}')
 
-    new_version = str(args.force_version) or bump_version(current_version, args.bump)
+    new_version = str(args.force_version) if args.force_version else bump_version(current_version, args.bump)
     print('New version: {}'.format(new_version))
     verify_and_push_tag(args.git_remote_name, args.remote_branch_name, new_version)


### PR DESCRIPTION
This should hopefully, finally, remove me from the release process of boundary-layer.

This:
1. enables the package-publish [github action](.github/workflows/python-publish.yml) to run in response to newly-created tags (hopefully)
1. adds a script for automating the creation of new tags, checking local git state to make sure everything's up to date, etc.

If this all works (to be determined), then my fellow admins should be able to initiate publishing of new boundary-layer versions to PyPI simply by creating a tag using the `release.py` script.  The credentials needed for publishing are stored in the Github Action secrets, so we do not need to distribute them anymore to human users (which is what had kept me in the loop for so long).

Let's see what happens!
