### PR TITLE
dict_generator should use valid py3 code

### DIFF
--- a/boundary_layer_default_plugin/config/generators/dict_generator.yaml
+++ b/boundary_layer_default_plugin/config/generators/dict_generator.yaml
@@ -20,7 +20,7 @@ imports:
               - namedtuple
 iterator_builder_method_code: |
     name_value = namedtuple('NameValue', ['name', 'value'])
-    return map(lambda (name, value): name_value(name, value), items.items())
+    return [name_value(name,value) for (name,value) in items.items()]
 item_name_builder_code: return item.name
 parameters_jsonschema:
     properties:


### PR DESCRIPTION
The original code uses the map/lambda pattern where the argument to the lambda was a list of two elements named `name` and `value`.  That doesn't work in python3 (see below) but the proposed list comprehension is equivalent and works in both.

Python2:
```
Python 2.7.16 (default, Feb 29 2020, 01:55:37)
[GCC 4.2.1 Compatible Apple LLVM 11.0.3 (clang-1103.0.29.20) (-macos10.15-objc- on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> the_list = ((1,1), (2,2))
>>> sum = lambda (x,y): x + y
>>> map(lambda  (x,y): x + y, the_list)
[2, 4]
>>> [x+y for (x,y) in the_list]
[2, 4]
>>>
```

Python3:
```
Python 3.7.3 (default, Apr  7 2020, 14:06:47)
[Clang 11.0.3 (clang-1103.0.32.59)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> the_list = ((1,1), (2,2))
>>> sum = lambda (x,y): x + y  # <---- invalid in py3
  File "<stdin>", line 1
    sum = lambda (x,y): x + y  # <---- invalid in py3
                 ^
SyntaxError: invalid syntax
>>> [x+y for (x,y) in the_list]
[2, 4]
>>>
```