### PR TITLE
trigger python deploy when a tag is pushed

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,7 +4,7 @@
 name: Upload Python Package
 
 on:
-  create:
+  push:
     tags:
     - '*'
 


### PR DESCRIPTION
This action was somehow triggered when I opened a PR (https://github.com/etsy/boundary-layer/actions/runs/176150978/workflow). Google suggests (but is not 100% clear) that switching the action to a tag getting pushed is the solution.