### PR TITLE
add .git extension as a valid option for the origin name

### DIFF
--- a/release.py
+++ b/release.py
@@ -69,7 +69,7 @@ def bump_version(version, bump_type):
 def check_remote(remote_name):
     """
     Print a warning if we are trying to deploy from a local clone of a fork, rather
-    than of a clone of the primary repository.
+    than from a clone of the primary repository.
     """
     output = subprocess.check_output(
         shlex.split(f'git remote get-url {remote_name}'),

--- a/release.py
+++ b/release.py
@@ -67,13 +67,19 @@ def bump_version(version, bump_type):
 
 
 def check_remote(remote_name):
+    """
+    Print a warning if we are trying to deploy from a local clone of a fork, rather
+    than of a clone of the primary repository.
+    """
     output = subprocess.check_output(
         shlex.split(f'git remote get-url {remote_name}'),
         encoding='utf-8'
     ).strip()
 
+    # let's check this the dumbest way possible
     if output not in [
         'git@github.com:etsy/boundary-layer',
+        'git@github.com:etsy/boundary-layer.git',
         'https://github.com/etsy/boundary-layer',
         'https://www.github.com/etsy/boundary-layer',
     ]:


### PR DESCRIPTION
The release script did not exhaustively cover the set of possible origin names 😭 