### PR TITLE
Add operator config for GCP Pubsub Publish operator

### DIFF
--- a/boundary_layer_default_plugin/config/operators/gcp_pubsub_publish.yaml
+++ b/boundary_layer_default_plugin/config/operators/gcp_pubsub_publish.yaml
@@ -23,7 +23,14 @@ parameters_jsonschema:
         topic:
             type: string
         messages:
-            type: list
+            type: array
+            items:
+                type: object
+                properties:
+                    data:
+                        type: bytes
+                    attributes:
+                        type: object
         project_id:
             type: string
         gcp_conn_id:

--- a/boundary_layer_default_plugin/config/operators/gcp_pubsub_publish.yaml
+++ b/boundary_layer_default_plugin/config/operators/gcp_pubsub_publish.yaml
@@ -1,0 +1,37 @@
+# Copyright 2020 Etsy Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+# see: https://github.com/apache/airflow/blob/master/airflow/providers/google/cloud/operators/pubsub.py
+
+name: gcp_pubsub_publish
+operator_class: PubSubPublishMessageOperator
+operator_class_module: airflow.providers.google.cloud.operators.pubsub
+schema_extends: base
+parameters_jsonschema:
+    properties:
+        topic:
+            type: string
+        messages:
+            type: list
+        project_id:
+            type: string
+        gcp_conn_id:
+            type: string
+        delegate_to:
+            type: string
+        project:
+            type: string
+    required:
+    - topic
+    - messages

--- a/boundary_layer_default_plugin/config/operators/gcp_pubsub_publish.yaml
+++ b/boundary_layer_default_plugin/config/operators/gcp_pubsub_publish.yaml
@@ -28,7 +28,10 @@ parameters_jsonschema:
                 type: object
                 properties:
                     data:
-                        type: bytes
+                        type:
+                            oneOf:
+                            - string
+                            - object
                     attributes:
                         type: object
         project_id:
@@ -42,3 +45,8 @@ parameters_jsonschema:
     required:
     - topic
     - messages
+
+property_preprocessors:
+    - type: to_binary_string
+      apply_to_properties:
+      - data

--- a/boundary_layer_default_plugin/config/operators/gcp_pubsub_publish.yaml
+++ b/boundary_layer_default_plugin/config/operators/gcp_pubsub_publish.yaml
@@ -28,10 +28,7 @@ parameters_jsonschema:
                 type: object
                 properties:
                     data:
-                        type:
-                            oneOf:
-                            - string
-                            - object
+                        type: [string, object]
                     attributes:
                         type: object
         project_id:
@@ -47,6 +44,6 @@ parameters_jsonschema:
     - messages
 
 property_preprocessors:
-    - type: to_binary_string
+    - type: pubsub_message_data_to_binary_string
       apply_to_properties:
-      - data
+      - messages

--- a/boundary_layer_default_plugin/config/operators/gcp_pubsub_publish.yaml
+++ b/boundary_layer_default_plugin/config/operators/gcp_pubsub_publish.yaml
@@ -31,6 +31,9 @@ parameters_jsonschema:
                         type: [string, object]
                     attributes:
                         type: object
+                anyOf:
+                - required: [data]
+                - required: [attributes]
         project_id:
             type: string
         gcp_conn_id:

--- a/boundary_layer_default_plugin/config/operators/gcp_pubsub_publish.yaml
+++ b/boundary_layer_default_plugin/config/operators/gcp_pubsub_publish.yaml
@@ -12,11 +12,11 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-# see: https://github.com/apache/airflow/blob/master/airflow/providers/google/cloud/operators/pubsub.py
+# see: https://github.com/apache/airflow/blob/1.10.3/airflow/contrib/operators/pubsub_operator.py
 
 name: gcp_pubsub_publish
-operator_class: PubSubPublishMessageOperator
-operator_class_module: airflow.providers.google.cloud.operators.pubsub
+operator_class: PubSubPublishOperator
+operator_class_module: airflow.contrib.operators.pubsub_operator
 schema_extends: base
 parameters_jsonschema:
     properties:
@@ -34,17 +34,16 @@ parameters_jsonschema:
                 anyOf:
                 - required: [data]
                 - required: [attributes]
-        project_id:
+        project:
             type: string
         gcp_conn_id:
             type: string
         delegate_to:
             type: string
-        project:
-            type: string
     required:
     - topic
     - messages
+    - project
 
 property_preprocessors:
     - type: pubsub_message_data_to_binary_string

--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -16,6 +16,7 @@
 import re
 import datetime
 from collections import namedtuple
+import json
 import marshmallow as ma
 import jinja2
 from boundary_layer.registry.types.preprocessor import PropertyPreprocessor
@@ -244,15 +245,15 @@ class PubsubMessageDataToBinaryString(PropertyPreprocessor):
         # Only support dict, arr, str args
         if not self._verify_valid_arg_type(arg):
             raise Exception(
-                'Error in preprocessor {} for argument`{}` w/ unsupported type {} : {}'.format(
+                'Error in preprocessor {} for argument`{}` w/ unsupported type: {}'.format(
                     self.type,
                     arg,
-                    type(arg),
-                    str(e)))
+                    type(arg))
+                )
         try:
             res_str = arg if not self._is_json(arg) else self._json_handler(arg)
             bin_string = b'{}'.format(res_str)
-        except Exception:
+        except Exception as e:
             raise Exception(
                 'Error in preprocessor {} for argument `{}`: {}'.format(
                     self.type,

--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -260,11 +260,11 @@ class PubsubMessageDataToBinaryString(PropertyPreprocessor):
                     str(e)))
         return bin_string
 
-    def _json_handler(arg):
+    def _json_handler(self, arg):
         return json.dumps(json.loads(arg))
 
-    def _is_json(arg):
+    def _is_json(self, arg):
         return isinstance(arg, dict) or isinstance(arg, list)
 
-    def _verify_valid_arg_type(arg):
+    def _verify_valid_arg_type(self, arg):
         return self._is_json(arg) or isinstance(arg, str)

--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -257,7 +257,7 @@ class PubsubMessageDataToBinaryString(PropertyPreprocessor):
         """
         bin_string = None
         try:
-            res_str = arg if not self._is_json(arg) else self._json_handler(arg)
+            res_str = arg if not self._is_dict(arg) else self._json_handler(arg)
             bin_string = base64.b64encode(res_str.encode('utf-8'))
         except Exception as e:
             raise Exception(
@@ -270,5 +270,5 @@ class PubsubMessageDataToBinaryString(PropertyPreprocessor):
     def _json_handler(self, arg):
         return json.dumps(arg)
 
-    def _is_json(self, arg):
+    def _is_dict(self, arg):
         return isinstance(arg, dict)

--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -216,3 +216,46 @@ class EnsureRenderedStringPattern(PropertyPreprocessor):
             context[field_name] = now
 
         return context
+
+class ToBinaryString(PropertyPreprocessor):
+    """
+    Converts various python types to binary strings.
+    Supported arg types: `list`, `dict`, and `str`
+
+    If arg is `list` or `dict` that data will be converted
+    into a json string, and then encoded into a binary string
+    """
+    type = "to_binary_string"
+
+    def imports(self):
+        return {'modules': ['json']}
+
+    def process_arg(self, arg, node, raw_args):
+        bin_string = None
+        # Only support dict, arr, str args
+        if not _verify_valid_arg_type(arg):
+            raise Exception(
+                'Error in preprocessor {} for argument`{}` w/ unsupported type {} : {}'.format(
+                    self.type,
+                    arg,
+                    type(arg),
+                    str(e)))
+        try:
+            res_str = arg if not _is_json(arg) else _json_handler(arg)
+            bin_string = b'{}'.format(res_str)
+        except Exception:
+            raise Exception(
+                'Error in preprocessor {} for argument `{}`: {}'.format(
+                    self.type,
+                    arg,
+                    str(e)))
+        return bin_string
+
+    def _json_handler(arg):
+        return json.dumps(json.loads(arg))
+
+    def _is_json(arg):
+        return isinstance(arg, dict) or isinstance(arg, list)
+
+    def _verify_valid_arg_type(arg):
+        return _is_json(arg) or isinstance(arg, str)

--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -17,6 +17,7 @@ import re
 import datetime
 from collections import namedtuple
 import json
+import base64
 import marshmallow as ma
 import jinja2
 from boundary_layer.registry.types.preprocessor import PropertyPreprocessor
@@ -234,7 +235,7 @@ class PubsubMessageDataToBinaryString(PropertyPreprocessor):
     type = "pubsub_message_data_to_binary_string"
 
     def imports(self):
-        return {'modules': ['json']}
+        return {'modules': ['json', 'base64']}
 
     def process_arg(self, arg, node, raw_args):
         """
@@ -257,7 +258,7 @@ class PubsubMessageDataToBinaryString(PropertyPreprocessor):
         bin_string = None
         try:
             res_str = arg if not self._is_json(arg) else self._json_handler(arg)
-            bin_string = res_str.encode('utf-8')
+            bin_string = base64.b64encode(res_str.encode('utf-8'))
         except Exception as e:
             raise Exception(
                 'Error in preprocessor {} for argument `{}`: {}'.format(

--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -240,7 +240,7 @@ class PubsubMessageDataToBinaryString(PropertyPreprocessor):
             res.append(message)
         return res
 
-    def _process_data_arg(self, arg, node, raw_args):
+    def _process_data_arg(self, arg):
         bin_string = None
         # Only support dict, arr, str args
         if not self._verify_valid_arg_type(arg):

--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -242,7 +242,7 @@ class PubsubMessageDataToBinaryString(PropertyPreprocessor):
     def _process_data_arg(self, arg, node, raw_args):
         bin_string = None
         # Only support dict, arr, str args
-        if not _verify_valid_arg_type(arg):
+        if not self._verify_valid_arg_type(arg):
             raise Exception(
                 'Error in preprocessor {} for argument`{}` w/ unsupported type {} : {}'.format(
                     self.type,
@@ -250,7 +250,7 @@ class PubsubMessageDataToBinaryString(PropertyPreprocessor):
                     type(arg),
                     str(e)))
         try:
-            res_str = arg if not _is_json(arg) else _json_handler(arg)
+            res_str = arg if not self._is_json(arg) else self._json_handler(arg)
             bin_string = b'{}'.format(res_str)
         except Exception:
             raise Exception(
@@ -267,4 +267,4 @@ class PubsubMessageDataToBinaryString(PropertyPreprocessor):
         return isinstance(arg, dict) or isinstance(arg, list)
 
     def _verify_valid_arg_type(arg):
-        return _is_json(arg) or isinstance(arg, str)
+        return self._is_json(arg) or isinstance(arg, str)

--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -217,20 +217,29 @@ class EnsureRenderedStringPattern(PropertyPreprocessor):
 
         return context
 
-class ToBinaryString(PropertyPreprocessor):
+class PubsubMessageDataToBinaryString(PropertyPreprocessor):
     """
-    Converts various python types to binary strings.
-    Supported arg types: `list`, `dict`, and `str`
+    Converts pubsub message data with various python types 
+    to binary strings.
+    Supported message data arg types: `list`, `dict`, and `str`
 
     If arg is `list` or `dict` that data will be converted
     into a json string, and then encoded into a binary string
     """
-    type = "to_binary_string"
+    type = "pubsub_message_data_to_binary_string"
 
     def imports(self):
         return {'modules': ['json']}
 
     def process_arg(self, arg, node, raw_args):
+        res = []
+        for message in arg:
+            if 'data' in message:
+                message['data'] = self._process_data_arg(message['data'])
+            res.append(message)
+        return res
+
+    def _process_data_arg(self, arg, node, raw_args):
         bin_string = None
         # Only support dict, arr, str args
         if not _verify_valid_arg_type(arg):

--- a/test/default_plugin/test_preprocessors.py
+++ b/test/default_plugin/test_preprocessors.py
@@ -76,7 +76,7 @@ def test_pubsub_message_to_binary_string_dictionary(mocker):
             'attributes': {'testing': 'is_cool'}
         }
     ]
-    expected_obj_str_encoded = json.dumps(preprocessed_obj).encode('utf-8')
+    expected_obj_str_encoded = base64.b64encode(json.dumps(preprocessed_obj).encode('utf-8'))
     processor = PubsubMessageDataToBinaryString({})
     res = processor.process_arg(preprocessed_messages, None, {})
     assert res[0]['data'] == expected_obj_str_encoded
@@ -92,7 +92,7 @@ def test_pubsub_message_to_binary_string_str(mocker):
             'data': preprocessed_str
         }
     ]
-    expected_str_encoded = preprocessed_str.encode('utf-8')
+    expected_str_encoded = base64.b64encode(preprocessed_str.encode('utf-8'))
     processor = PubsubMessageDataToBinaryString({})
     res = processor.process_arg(preprocessed_messages, None, {})
     assert res[0]['data'] == expected_str_encoded

--- a/test/default_plugin/test_preprocessors.py
+++ b/test/default_plugin/test_preprocessors.py
@@ -63,3 +63,36 @@ def test_ensure_rendered_string_pattern(mocker):
 
     with pytest.raises(Exception):
         renderer.process_arg("My-<item.value>-cluster", None, {})
+
+def test_pubsub_message_to_binary_string_dictionary(mocker):
+    """
+    Given: User provides message with `dict` type data property
+    Assert: Data value is converted to json and encoded into binary string
+    """
+    preprocessed_obj = {'hello': 'world'}
+    preprocessed_messages = [
+        {
+            'data': preprocessed_obj,
+            'attributes': {'testing': 'is_cool'}
+        }
+    ]
+    expected_obj_str_encoded = json.dumps(preprocessed_obj).encode('utf-8')
+    processor = PubsubMessageDataToBinaryString({})
+    res = processor.process_arg(preprocessed_messages, None, {})
+    assert res[0]['data'] == expected_obj_str_encoded
+
+def test_pubsub_message_to_binary_string_str(mocker):
+    """
+    Given: User provides message with `str` type data property
+    Assert: Data value is encoded into binary string
+    """
+    preprocessed_str = 'helloworld'
+    preprocessed_messages = [
+        {
+            'data': preprocessed_str
+        }
+    ]
+    expected_str_encoded = preprocessed_str.encode('utf-8')
+    processor = PubsubMessageDataToBinaryString({})
+    res = processor.process_arg(preprocessed_messages, None, {})
+    assert res[0]['data'] == expected_str_encoded


### PR DESCRIPTION
This PR makes the GCP Pubsub Publish operator available in boundary-layer.

https://airflow.readthedocs.io/en/latest/_api/airflow/providers/google/cloud/operators/pubsub/index.html