### PR TITLE
Registered PubsubMessageDataToBinaryString preprocessor in plugin.py to fix bug

### DIFF
--- a/boundary_layer_default_plugin/plugin.py
+++ b/boundary_layer_default_plugin/plugin.py
@@ -17,7 +17,7 @@ import os
 from boundary_layer.plugins import BasePlugin, PluginPriority
 from .oozie_plugin import DefaultOozieParserPlugin
 from .preprocessors import DateStringToDatetime, BuildTimedelta, EnsureRenderedStringPattern
-from .preprocessors import KubernetesPrep
+from .preprocessors import KubernetesPrep, PubsubMessageDataToBinaryString
 
 
 class DefaultPlugin(BasePlugin):
@@ -33,4 +33,5 @@ class DefaultPlugin(BasePlugin):
         DateStringToDatetime,
         BuildTimedelta,
         EnsureRenderedStringPattern,
-        KubernetesPrep]
+        KubernetesPrep,
+        PubsubMessageDataToBinaryString]


### PR DESCRIPTION
This fixes a bug introduced by my previous change to add a pubsub publish operator, and a corresponding preprocessor. I was unaware that the preprocessor had to be registered in `boundary_layer_default_plugin/plugin.py`. This change fixes that.