### PR TITLE
Add a comment on the export_format

### DIFF
--- a/boundary_layer_default_plugin/config/operators/bigquery_to_gcs.yaml
+++ b/boundary_layer_default_plugin/config/operators/bigquery_to_gcs.yaml
@@ -27,7 +27,7 @@ parameters_jsonschema:
         compression:
             type: string
         export_format:
-            type: string
+            type: string # On tag 1.10.3, airflow natively supports these formats https://github.com/apache/airflow/blob/1.10.3/airflow/contrib/hooks/bigquery_hook.py#L1096-L1098
         field_delimiter:
             type: string
         print_header:


### PR DESCRIPTION
If you put a data format as `JSON`, it won't work. The correct name is `NEWLINE_DELIMITED_JSON`. I add a line of comment here to avoid people to step into this trap. 

