### PR TITLE
Use enum to replace plain string in the export_format of bigquery_to_gcs

### DIFF
--- a/boundary_layer_default_plugin/config/operators/bigquery_to_gcs.yaml
+++ b/boundary_layer_default_plugin/config/operators/bigquery_to_gcs.yaml
@@ -12,7 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-# see: https://github.com/apache/airflow/blob/1.10.3/airflow/contrib/operators/bigquery_to_gcs.py
+# for the native operator, see: https://github.com/apache/airflow/blob/1.10.3/airflow/contrib/operators/bigquery_to_gcs.py
+# for the export_format, see: https://github.com/apache/airflow/blob/1.10.3/airflow/contrib/hooks/bigquery_hook.py#L1096-L1098\
 
 name: bigquery_to_gcs
 operator_class: BigQueryToCloudStorageOperator
@@ -28,6 +29,14 @@ parameters_jsonschema:
             type: string
         export_format:
             type: string
+            enum: [
+                CSV,
+                NEWLINE_DELIMITED_JSON,
+                AVRO,
+                GOOGLE_SHEETS,
+                DATASTORE_BACKUP,
+                PARQUET
+            ]
         field_delimiter:
             type: string
         print_header:


### PR DESCRIPTION
People would easily make mistakes if they replace `CSV` with `JSON` in the export_format because `JSON` is not in the allowed format list. 

https://github.com/apache/airflow/blob/1.10.3/airflow/contrib/hooks/bigquery_hook.py#L1096-L1098

The correct argument for exporting JSON should be `NEWLINE_DELIMITED_JSON`, which is implicit in the current yaml template. If you actually pass `JSON` to the `export_format` field, Airflow will automatically correct it into the default value `CSV` and you will get unexpected result even when you think you set the "correct" argument here. 

Hereby we use the enum to replace the original plain string to enforce the argument check at the first place, so that you won't be confused by the automatic fallback to CSV. 
