### PR TITLE
Add support for python 3.9

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
         'jinja2>=2.8.1,<3.0',
         'pyyaml>=4.2b1',
         'marshmallow>=2.13.6,<3.0',
-        'networkx>=2.1,<2.3',
+        'networkx>=2.5,<2.6',
         'xmltodict>=0.11.0,<1.0',
         'six>=1.11.0,<2.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
         'jinja2>=2.8.1,<3.0',
         'pyyaml>=4.2b1',
         'marshmallow>=2.13.6,<3.0',
-        'networkx>=2.5,<2.6',
+        'networkx>=2.4,<2.5',
         'xmltodict>=0.11.0,<1.0',
         'six>=1.11.0,<2.0',
     ],


### PR DESCRIPTION
Only a small bump to `networkx` was required to get passing tests from 3.9