### PR TITLE
Drop support for python 3.5

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -35,5 +35,5 @@ jobs:
         flake8 boundary_layer boundary_layer_default_plugin bin test --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with tox
       run: |
-        # py`echo ${{ matrix.python-version }} | tr -d '.'`  yields py27, py35, etc. which is what tox needs
+        # py`echo ${{ matrix.python-version }} | tr -d '.'`  yields py36, py37, etc. which is what tox needs
         tox --recreate -e py`echo ${{ matrix.python-version }} | tr -d '.'` test

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,5 @@ setuptools.setup(
     license = 'Apache License 2.0',
     keywords = 'airflow',
     zip_safe = False,
-    python_requires='>=3.5',
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
Python 3.5 is EOL and tools like pip will stop working with it so we should drop it.