### PR TITLE
MAD-73 Add gcs_to_s3 to the boundary layer

### DIFF
--- a/boundary_layer_default_plugin/config/operators/gcs_to_s3.yaml
+++ b/boundary_layer_default_plugin/config/operators/gcs_to_s3.yaml
@@ -1,0 +1,47 @@
+# Copyright 2021 Etsy Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+# see: https://airflow.apache.org/docs/apache-airflow/1.10.9/_modules/airflow/contrib/operators/gcs_to_s3.html
+
+name: gcs_to_s3
+operator_class: GoogleCloudStorageToS3Operator
+operator_class_module: airflow.contrib.operators.gcs_to_s3
+schema_extends: base
+parameters_jsonschema:
+    properties:
+        bucket:
+            type: string
+        prefix:
+            type: string
+        delimiter:
+            type: string
+        google_cloud_storage_conn_id:
+            type: string
+        delegate_to:
+            type: string
+        dest_aws_conn_id:
+            type: string
+        dest_s3_key:
+            type: string
+        dest_verify:
+            type: boolean
+        replace:
+            type: boolean
+
+    required:
+        - bucket
+        - prefix
+        - delimiter
+        - dest_aws_conn_id
+        - dest_s3_key


### PR DESCRIPTION
Exposing the gcs_to_s3 operator in the boundary layer to be used by the MarTech Tinuiti integration.

Source operator:
https://airflow.apache.org/docs/apache-airflow/1.10.6/_api/airflow/contrib/operators/gcs_to_s3/index.html