### PR TITLE
Revert "Allow networkx upper bound >=2.5 to support py3.9 (#107)"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
         'jinja2>=2.8.1,<3.0',
         'pyyaml>=4.2b1',
         'marshmallow>=2.13.6,<3.0',
-        'networkx>=2.4,<3.0',
+        'networkx>=2.4,<2.5',
         'xmltodict>=0.11.0,<1.0',
         'six>=1.11.0,<2.0',
     ],


### PR DESCRIPTION
This reverts commit 6a0acfcc506a25aa7c3e6f33f569ba7392e739f3.