### PR TITLE
Fix KubernetesPodOperator's broken resources arg

### DIFF
--- a/boundary_layer_default_plugin/config/operators/kubernetes.yaml
+++ b/boundary_layer_default_plugin/config/operators/kubernetes.yaml
@@ -111,9 +111,3 @@ property_preprocessors:
       class_name: airflow.contrib.kubernetes.secret.Secret
     apply_to_properties:
       - secrets
-  - type: kubernetes_prep
-    properties:
-      class_name: airflow.contrib.kubernetes.pod.Resources
-    apply_to_properties:
-      - resources
-  


### PR DESCRIPTION
Since at least airflow version 1.10.4 the kubernetes pod operator resources argument has taken a dictionary rather than the actual resources object. [reference docs](https://airflow.apache.org/docs/apache-airflow/1.10.4/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html). This change updates the config to properly set resource constraints.

Without this change, users of the Kubernetes Pod Operator will get the following error in the generated airflow;

```
TypeError: airflow.kubernetes.pod.Resources() argument after ** must be a mapping, not Resources
```