### PR TITLE
[bugfix] Fix handling of bytes

### DIFF
--- a/boundary_layer/builders/util.py
+++ b/boundary_layer/builders/util.py
@@ -120,7 +120,7 @@ def format_value(value):
 
         return '{{ {items} }}'.format(items=','.join(pairs))
 
-    if isinstance(value, (int, float, type(None))):
+    if isinstance(value, (int, float, type(None), bytes)):
         return str(value)
 
     if isinstance(value, (datetime.datetime, datetime.timedelta, GenericNamedParameterPasser)):

--- a/test/builders/test_util.py
+++ b/test/builders/test_util.py
@@ -79,6 +79,8 @@ def test_format_value():
 
     assert util.format_value(None) == 'None'
 
+    assert util.format_value(b'hello world') == "b'hello world'"
+
     with pytest.raises(Exception):
         assert util.format_value(set(10))
 


### PR DESCRIPTION
Closes #79 

One of our operators has an optional field that requires bytes. If that field is populated, it will error out when it gets formatted. This should fix that.