### PR TITLE
[bugfix] Send str instead of bytes to pubsub op

### DIFF
--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -258,7 +258,7 @@ class PubsubMessageDataToBinaryString(PropertyPreprocessor):
         bin_string = None
         try:
             res_str = arg if not self._is_dict(arg) else self._json_handler(arg)
-            bin_string = base64.b64encode(res_str.encode('utf-8'))
+            bin_string = base64.b64encode(res_str.encode('utf-8')).decode('utf-8')
         except Exception as e:
             raise Exception(
                 'Error in preprocessor {} for argument `{}`: {}'.format(

--- a/test/default_plugin/test_preprocessors.py
+++ b/test/default_plugin/test_preprocessors.py
@@ -77,7 +77,8 @@ def test_pubsub_message_to_binary_string_dictionary(mocker):
             'attributes': {'testing': 'is_cool'}
         }
     ]
-    expected_obj_str_encoded = base64.b64encode(json.dumps(preprocessed_obj).encode('utf-8'))
+    expected_obj_str_encoded = \
+        base64.b64encode(json.dumps(preprocessed_obj).encode('utf-8')).decode('utf-8')
     processor = PubsubMessageDataToBinaryString({})
     res = processor.process_arg(preprocessed_messages, None, {})
     assert res[0]['data'] == expected_obj_str_encoded
@@ -94,7 +95,8 @@ def test_pubsub_message_to_binary_string_str(mocker):
             'data': preprocessed_str
         }
     ]
-    expected_str_encoded = base64.b64encode(preprocessed_str.encode('utf-8'))
+    expected_str_encoded = \
+        base64.b64encode(preprocessed_str.encode('utf-8')).decode('utf-8')
     processor = PubsubMessageDataToBinaryString({})
     res = processor.process_arg(preprocessed_messages, None, {})
     assert res[0]['data'] == expected_str_encoded


### PR DESCRIPTION
I tested this E2E and it seems to work fine w/o corrupting the message