### PR TITLE
[generators] Fix bug during empty string conversion w/ generators

### DIFF
--- a/boundary_layer/builders/util.py
+++ b/boundary_layer/builders/util.py
@@ -136,7 +136,10 @@ def format_value(value):
     if len(components) == 1:
         return components[0]
 
-    return '({})'.format(' + '.join(components))
+    result = '({})'.format(' + '.join(components))
+    if result == '()':
+        return "''"
+    return result
 
 
 def comment(value):

--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -219,6 +219,7 @@ class EnsureRenderedStringPattern(PropertyPreprocessor):
 
         return context
 
+
 class PubsubMessageDataToBinaryString(PropertyPreprocessor):
     """
     Converts pubsub message data with various python types

--- a/test/builders/test_util.py
+++ b/test/builders/test_util.py
@@ -79,6 +79,8 @@ def test_format_value():
 
     assert util.format_value(None) == 'None'
 
+    assert util.format_value("") == "''"
+
     with pytest.raises(Exception):
         assert util.format_value(set(10))
 


### PR DESCRIPTION
Previously, this was true:

```
assert util.format_value("") == "()"
```

This isn't what we want when it comes to generator conversion and its usage [here](https://github.com/etsy/boundary-layer/blob/master/boundary_layer/builders/templates/generator_operator.j2#L35) becuase what will end up happening is we will create a for loop like this:

```py
for (index, item) in enumerate(language_sensors_iterable_builder(
            items = [{ 'name': 'model_A','index': ('a' if 1 else 'b') },{ 'name': 'model_B','index': () }],
        )):
```

What we actually want to represent is this:
```py
for (index, item) in enumerate(language_sensors_iterable_builder(                           
            items = [{ 'name': 'model_A','index': ('a' if 1 else 'b') },{ 'name': 'model_B','index': '' }],
        )):                                                                                   
```

The difference is subtle but it will result in bugs during airflow test dag parsing as a result of a tuple being passed instead of an empty string type:

```
>>> {'a': (), 'b': ''}
{'a': (), 'b': ''}
>>> data = {'a': (), 'b': ''}
>>> data['a']
()
>>> type(data['a'])
<class 'tuple'>
>>> data['b']
''
>>> type(data['b'])
<class 'str'>
```