### PR TITLE
Pin markupsafe==2.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setuptools.setup(
         'networkx>=2.4,<2.5',
         'xmltodict>=0.11.0,<1.0',
         'six>=1.11.0,<2.0',
+        'markupsafe==2.0.1',
     ],
     scripts = ['bin/boundary-layer'],
     classifiers = [


### PR DESCRIPTION
Ref https://github.com/aws/aws-sam-cli/issues/3661

A new version of markupsafe released yesterday removed support for soft_unicode which breaks boundary-layer with `ImportError: cannot import name 'soft_unicode' from 'markupsafe`

This pins markupsafe==2.0.1 to avoid upgrading to the incompatible version.