### PR TITLE
Add params to base_operator

### DIFF
--- a/boundary_layer_default_plugin/config/operators/base.yaml
+++ b/boundary_layer_default_plugin/config/operators/base.yaml
@@ -74,6 +74,10 @@ parameters_jsonschema:
             type: string
         task_id:
             type: string
+        params:
+            type: object
+            additionalProperties:
+                type: string
     additionalProperties: false
     required:
         - dag

--- a/boundary_layer_default_plugin/config/operators/base.yaml
+++ b/boundary_layer_default_plugin/config/operators/base.yaml
@@ -76,8 +76,6 @@ parameters_jsonschema:
             type: string
         params:
             type: object
-            additionalProperties:
-                type: string
     additionalProperties: false
     required:
         - dag


### PR DESCRIPTION
Params is a task level property that can override dag defaults

https://github.com/apache/airflow/blob/1.10.3/airflow/models/__init__.py#L2987-L2989

Expose this to users

## Description

> Please include a brief summary of the changes.

## Context / Why are we making this change?

> Please include details on why this change is necessary, and any applicable tickets, design docs, or documentation links.

## Testing and QA Plan

> How has this work been tested or QA'd?

## Impact

> What are the implications of these changes? Are there any cross-cutting concerns to keep in mind?
