### PR TITLE
add proprocessor required for time sensor

### DIFF
--- a/boundary_layer_default_plugin/plugin.py
+++ b/boundary_layer_default_plugin/plugin.py
@@ -37,6 +37,7 @@ class DefaultPlugin(BasePlugin):
     property_preprocessors = [
         BuildTimedelta,
         DateStringToDatetime,
+	TimeStringToTime,
         EnsureRenderedStringPattern,
         KubernetesPrep,
         PubsubMessageDataToBinaryString,

--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -46,6 +46,25 @@ class DateStringToDatetime(PropertyPreprocessor):
         return date
 
 
+class TimeStringToTime(PropertyPreprocessor):
+    type = "to_time"
+
+    def imports(self):
+        return {'modules': ['datetime']}
+
+    def process_arg(self, arg, node, raw_args):
+        time = None
+        try:
+            time = datetime.datetime.strptime(arg, '%H:%M').time()
+        except ValueError as e:
+            raise Exception(
+                'Error in preprocessor {} for argument `{}`: {}'.format(
+                    self.type,
+                    arg,
+                    str(e)))
+
+        return time
+
 class BuildKubernetesSchema(StrictSchema):
     class_name = ma.fields.String(required=True)
 


### PR DESCRIPTION
<!-- Need support on our inclusive code practices? Visit http://go/inclusivecode -->

## Description

Add a preprocessor required to convert string to time object, which is required to add the `time_sensor` to boundary-layer.

## Context / Why are we making this change?

WINS squad is working on an automated slot management service for BigQuery called Slot Machine. The service lives in CloudRun and needs to be deployed at specific times of the day to resolve slot contention issues in BigQuery while controlling costs and optimizing performance. We would like to simplify our DAGs in Airflow by keeping relevant tasks together in a single DAG, but scheduling them for specific times of the day. The `time_sensor` in Airflow solves for this, however, it needs to be added to Boundary Layer, alongside this processor.

## Testing and QA Plan

Function has been tested successfully.

## Impact

NA.
