### PR TITLE
Add datetime.time.

### DIFF
--- a/boundary_layer/builders/util.py
+++ b/boundary_layer/builders/util.py
@@ -123,7 +123,7 @@ def format_value(value):
     if isinstance(value, (int, float, type(None))):
         return str(value)
 
-    if isinstance(value, (datetime.datetime, datetime.timedelta, GenericNamedParameterPasser)):
+    if isinstance(value, (datetime.datetime, datetime.timedelta, datetime.time, GenericNamedParameterPasser)):
         return format_value('<<{}>>'.format(repr(value)))
 
     if not isinstance(value, six.string_types):


### PR DESCRIPTION
<!-- Need support on our inclusive code practices? Visit http://go/inclusivecode -->

## Description

Adding datetime.time to handler options.

## Context / Why are we making this change?

Follow up fix for this [PR](https://github.com/etsy/boundary-layer/pull/135) which added a preprocessor for time. When testing, this error surfaced with a `10:30` string:

`Exception: Cannot format value `10:30:00`: no handler for type <class 'datetime.time'>`

This change should solve for this.

## Testing and QA Plan

> How has this work been tested or QA'd?

## Impact

> What are the implications of these changes? Are there any cross-cutting concerns to keep in mind?
