### PR TITLE
Add support for None in timedelta preprocessor

### DIFF
--- a/boundary_layer_default_plugin/preprocessors.py
+++ b/boundary_layer_default_plugin/preprocessors.py
@@ -130,6 +130,9 @@ class BuildTimedelta(PropertyPreprocessor):
     def process_arg(self, arg, node, raw_args):
         delta = None
 
+        if arg is None:
+            return delta
+
         try:
             timedelta_arg = {self.properties['units']: arg}
             delta = datetime.timedelta(**timedelta_arg)

--- a/test/default_plugin/test_preprocessors.py
+++ b/test/default_plugin/test_preprocessors.py
@@ -1,6 +1,7 @@
 import pytest
 from boundary_layer.logger import logger
 from boundary_layer_default_plugin.preprocessors import *
+from datetime import timedelta
 from mock import Mock
 
 
@@ -122,6 +123,22 @@ def test_stringify_env_args():
         'ENV_VAR_LIST_OF_DICTS': '[{"a": "b"}]',
     }
     processor = StringifyObject({})
+    res = processor.process_arg(preprocessed_messages, None, {})
+
+    assert res == expected
+
+
+def test_to_timedelta():
+    preprocessed_messages = 3600
+    expected = timedelta(seconds=3600)
+    processor = BuildTimedelta({"units": "seconds"})
+    res = processor.process_arg(preprocessed_messages, None, {})
+
+    assert res == expected
+
+    preprocessed_messages = None
+    expected = None
+    processor = BuildTimedelta({"units": "seconds"})
     res = processor.process_arg(preprocessed_messages, None, {})
 
     assert res == expected


### PR DESCRIPTION
Allow None (or null) as an argument for the timedelta preprocessor. Motivation is that we'd like to pass a null SLA at times for certain operators.