### PR TITLE
Relax constraints on jinja2 dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     install_requires = [
         'semver>=2.7.0,<3.0',
         'jsonschema>=2.6.0,<3.0',
-        'jinja2>=2.8.1,<3.0',
+        'jinja2>=2.8.1',
         'pyyaml>=4.2b1',
         'marshmallow>=2.13.6,<3.0',
         'networkx>=2.4,<2.5',


### PR DESCRIPTION
## Description

Relax constraints on jinja2 dep. There don't seem to be any breaking changes from 2.x to 3.0 (https://jinja.palletsprojects.com/en/3.1.x/changes/).

## Context / Why are we making this change?

We are running into a dependency conflict. Specifically, flask requires jinja2>=3.0.

## Testing and QA Plan

Run tests with recent jinja2.