### PR TITLE
Allow networkx<3.0 to allow security fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
         'jinja2>=2.8.1',
         'pyyaml>=4.2b1',
         'marshmallow>=2.13.6,<3.0',
-        'networkx>=2.4,<2.5',
+        'networkx>=2.4,<3.0',
         'xmltodict>=0.11.0,<1.0',
         'six>=1.11.0,<2.0',
         'markupsafe==2.0.1',


### PR DESCRIPTION
## Description

Allow networkx<3.0 to allow security fixes

## Context / Why are we making this change?

networkx before 2.6 is flagged for security vulnerabilities as described at https://security.snyk.io/vuln/SNYK-PYTHON-NETWORKX-1062709

## Testing and QA Plan

> How has this work been tested or QA'd?

Trusting automated test coverage.

## Impact

> What are the implications of these changes? Are there any cross-cutting concerns to keep in mind?

networkx<3.0 was allowed with https://github.com/etsy/boundary-layer/pull/107 , however was reverted with https://github.com/etsy/boundary-layer/pull/108 , and no context was provided why it was reverted, but hopefully this change is fine now given the passage of time.